### PR TITLE
JUIP-78-checkbox component

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,17 +1,32 @@
+const {getDefaultConfig} = require('metro-config');
+
 /**
  * Metro configuration for React Native
  * https://github.com/facebook/react-native
  *
- * @format
+ *
  */
 
-module.exports = {
-	transformer: {
-		getTransformOptions: async () => ({
-			transform: {
-				experimentalImportSupport: false,
-				inlineRequires: false,
-			},
-		}),
-	},
+const createMetroConfig = async () => {
+	const {
+		resolver: {sourceExts, assetExts},
+	} = await getDefaultConfig();
+
+	return {
+		transformer: {
+			getTransformOptions: async () => ({
+				transform: {
+					experimentalImportSupport: false,
+					inlineRequires: false,
+				},
+			}),
+			babelTransformerPath: require.resolve('react-native-svg-transformer'),
+		},
+		resolver: {
+			assetExts: assetExts.filter((ext) => ext !== 'svg'),
+			sourceExts: [...sourceExts, 'svg'],
+		},
+	};
 };
+
+module.exports = createMetroConfig();

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"react": "16.13.1",
 		"react-native": "0.63.5",
 		"react-native-storybook-loader": "^2.0.5",
+		"react-native-svg-transformer": "^1.0.0",
 		"react-test-renderer": "16.13.1",
 		"typescript": "^3.8.3"
 	},
@@ -91,7 +92,9 @@
 			"npm run test:commit"
 		]
 	},
-	"dependencies": {},
+	"dependencies": {
+		"react-native-svg": "12.1.1"
+	},
 	"config": {
 		"react-native-storybook-loader": {
 			"searchDir": [

--- a/src/components/CheckBox/icon/CheckedIcon.test.tsx
+++ b/src/components/CheckBox/icon/CheckedIcon.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import {create} from 'react-test-renderer';
+import CheckedIcon from './CheckedIcon';
+
+describe('CheckedIcon component', () => {
+	it('render correctly', () => {
+		const {toJSON} = create(<CheckedIcon color="red" size={18} />);
+
+		expect(toJSON()).toBeTruthy();
+	});
+});

--- a/src/components/CheckBox/icon/CheckedIcon.tsx
+++ b/src/components/CheckBox/icon/CheckedIcon.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
+import {base} from '../../../theme/palette';
 import Svg, {Path} from 'react-native-svg';
 
 interface IconProps {
@@ -9,9 +10,9 @@ interface IconProps {
 
 const CheckedIcon = ({color, size}: IconProps) => (
 	<View>
-		<Svg width={size} height={size} viewBox="3 3 18 18" fill="none">
+		<Svg width={size} height={size} viewBox="0 0 16 16" fill="none">
 			<Path
-				d="M19 3ZM10 17L5 12.1923L6.4 10.8462L10 14.3077L17.6 7L19 8.34615L10 17Z"
+				d="M3 0H3ZM4 8.0534L7.05987 11L12 5.28272L10.5916 4L6.93119 8.22932L5.29401 6.64607L4 8.0534Z"
 				fill={color}
 			/>
 		</Svg>
@@ -19,8 +20,8 @@ const CheckedIcon = ({color, size}: IconProps) => (
 );
 
 CheckedIcon.defaultProps = {
-	color: '#FFF',
-	size: 18,
+	color: base.white,
+	size: 16,
 };
 
 export default CheckedIcon;

--- a/src/components/CheckBox/icon/CheckedIcon.tsx
+++ b/src/components/CheckBox/icon/CheckedIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {View} from 'react-native';
+import Svg, {Path} from 'react-native-svg';
+
+interface IconProps {
+	color?: string;
+	size?: number;
+}
+
+const CheckedIcon = ({color, size}: IconProps) => (
+	<View>
+		<Svg width={size} height={size} viewBox="3 3 18 18" fill="none">
+			<Path
+				d="M19 3ZM10 17L5 12.1923L6.4 10.8462L10 14.3077L17.6 7L19 8.34615L10 17Z"
+				fill={color}
+			/>
+		</Svg>
+	</View>
+);
+
+CheckedIcon.defaultProps = {
+	color: '#FFF',
+	size: 18,
+};
+
+export default CheckedIcon;

--- a/src/components/CheckBox/index.test.tsx
+++ b/src/components/CheckBox/index.test.tsx
@@ -68,4 +68,17 @@ describe('CheckBox component', () => {
 			expect(root).toBeTruthy();
 		});
 	});
+
+	describe('has border radius', () => {
+		const valueChangeFn = jest.fn();
+		const borderRadiusMock = 30;
+
+		const {root} = create(
+			<CheckBox checked={false} onValueChange={valueChangeFn} borderRadius={borderRadiusMock} />
+		);
+		const ViewComponent = root.findByType(TouchableOpacity);
+		const {borderRadius} = ViewComponent.props.children.props.style;
+
+		expect(borderRadius).toBe(borderRadiusMock);
+	});
 });

--- a/src/components/CheckBox/index.test.tsx
+++ b/src/components/CheckBox/index.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import CheckBox from './index';
+import {create} from 'react-test-renderer';
+import {TouchableOpacity} from 'react-native';
+
+describe('CheckBox component', () => {
+	it('render correctly', () => {
+		const {toJSON} = create(<CheckBox value={false} />);
+
+		expect(toJSON()).toBeTruthy();
+	});
+
+	describe('value', () => {
+		it('when is true, backgroundColor is #2979FF', () => {
+			const {root} = create(<CheckBox value={true} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			const {style} = ViewComponent.props.children.props;
+
+			expect(style.backgroundColor).toBe('#2979FF');
+			expect(style.width).toBe(18);
+		});
+
+		it('when is false, borderColor is #939598', () => {
+			const {root} = create(<CheckBox value={false} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			const {style} = ViewComponent.props.children.props;
+
+			expect(style.borderColor).toBe('#939598');
+			expect(style.width).toBe(18);
+		});
+	});
+
+	describe('disabled', () => {
+		it('when is true, opacity is 0.6', () => {
+			const {root} = create(<CheckBox value={false} disabled={true} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			const {style} = ViewComponent.props.children.props;
+
+			expect(style.opacity).toBe(0.6);
+		});
+
+		it('when is false, opacity is 1', () => {
+			const {root} = create(<CheckBox value={false} disabled={false} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			const {style} = ViewComponent.props.children.props;
+
+			expect(style.opacity).toBe(1);
+		});
+	});
+
+	describe('onValueChange', () => {
+		it('when is called', () => {
+			const valueChangeFn = jest.fn();
+
+			const {root} = create(<CheckBox value={false} onValueChange={valueChangeFn} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			ViewComponent.props.onPress();
+
+			expect(valueChangeFn).toHaveBeenCalledTimes(1);
+			expect(valueChangeFn).toBeCalled();
+		});
+
+		it('when is an anonymous function and is called when ViewComponent is pressed', () => {
+			const {root} = create(<CheckBox value={false} />);
+			const ViewComponent = root.findByType(TouchableOpacity);
+			ViewComponent.props.onPress();
+
+			expect(root).toBeTruthy();
+		});
+	});
+});

--- a/src/components/CheckBox/index.test.tsx
+++ b/src/components/CheckBox/index.test.tsx
@@ -5,14 +5,14 @@ import {TouchableOpacity} from 'react-native';
 
 describe('CheckBox component', () => {
 	it('render correctly', () => {
-		const {toJSON} = create(<CheckBox value={false} />);
+		const {toJSON} = create(<CheckBox checked={false} />);
 
 		expect(toJSON()).toBeTruthy();
 	});
 
 	describe('value', () => {
 		it('when is true, backgroundColor is #2979FF', () => {
-			const {root} = create(<CheckBox value={true} />);
+			const {root} = create(<CheckBox checked={true} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
@@ -21,7 +21,7 @@ describe('CheckBox component', () => {
 		});
 
 		it('when is false, borderColor is #939598', () => {
-			const {root} = create(<CheckBox value={false} />);
+			const {root} = create(<CheckBox checked={false} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
@@ -32,7 +32,7 @@ describe('CheckBox component', () => {
 
 	describe('disabled', () => {
 		it('when is true, opacity is 0.6', () => {
-			const {root} = create(<CheckBox value={false} disabled={true} />);
+			const {root} = create(<CheckBox checked={false} disabled={true} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
@@ -40,7 +40,7 @@ describe('CheckBox component', () => {
 		});
 
 		it('when is false, opacity is 1', () => {
-			const {root} = create(<CheckBox value={false} disabled={false} />);
+			const {root} = create(<CheckBox checked={false} disabled={false} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
@@ -52,7 +52,7 @@ describe('CheckBox component', () => {
 		it('when is called', () => {
 			const valueChangeFn = jest.fn();
 
-			const {root} = create(<CheckBox value={false} onValueChange={valueChangeFn} />);
+			const {root} = create(<CheckBox checked={false} onValueChange={valueChangeFn} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			ViewComponent.props.onPress();
 
@@ -61,7 +61,7 @@ describe('CheckBox component', () => {
 		});
 
 		it('when is an anonymous function and is called when ViewComponent is pressed', () => {
-			const {root} = create(<CheckBox value={false} />);
+			const {root} = create(<CheckBox checked={false} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			ViewComponent.props.onPress();
 

--- a/src/components/CheckBox/index.test.tsx
+++ b/src/components/CheckBox/index.test.tsx
@@ -17,7 +17,7 @@ describe('CheckBox component', () => {
 			const {style} = ViewComponent.props.children.props;
 
 			expect(style.backgroundColor).toBe('#2979FF');
-			expect(style.width).toBe(18);
+			expect(style.width).toBe(16);
 		});
 
 		it('when is false, borderColor is #939598', () => {
@@ -26,59 +26,43 @@ describe('CheckBox component', () => {
 			const {style} = ViewComponent.props.children.props;
 
 			expect(style.borderColor).toBe('#939598');
-			expect(style.width).toBe(18);
+			expect(style.width).toBe(16);
 		});
 	});
 
 	describe('disabled', () => {
-		it('when is true, opacity is 0.6', () => {
+		it('when is checked is false color is grey[200] (#D5D7DB)', () => {
 			const {root} = create(<CheckBox checked={false} disabled={true} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
-			expect(style.opacity).toBe(0.6);
+			expect(style.borderColor).toBe('#D5D7DB');
 		});
 
-		it('when is false, opacity is 1', () => {
-			const {root} = create(<CheckBox checked={false} disabled={false} />);
+		it('when is checked is true color is grey[200] (#D5D7DB)', () => {
+			const {root} = create(<CheckBox checked disabled={true} />);
 			const ViewComponent = root.findByType(TouchableOpacity);
 			const {style} = ViewComponent.props.children.props;
 
-			expect(style.opacity).toBe(1);
-		});
-	});
-
-	describe('onValueChange', () => {
-		it('when is called', () => {
-			const valueChangeFn = jest.fn();
-
-			const {root} = create(<CheckBox checked={false} onValueChange={valueChangeFn} />);
-			const ViewComponent = root.findByType(TouchableOpacity);
-			ViewComponent.props.onPress();
-
-			expect(valueChangeFn).toHaveBeenCalledTimes(1);
-			expect(valueChangeFn).toBeCalled();
-		});
-
-		it('when is an anonymous function and is called when ViewComponent is pressed', () => {
-			const {root} = create(<CheckBox checked={false} />);
-			const ViewComponent = root.findByType(TouchableOpacity);
-			ViewComponent.props.onPress();
-
-			expect(root).toBeTruthy();
+			expect(style.backgroundColor).toBe('#D5D7DB');
 		});
 	});
 
 	describe('has border radius', () => {
-		const valueChangeFn = jest.fn();
 		const borderRadiusMock = 30;
 
-		const {root} = create(
-			<CheckBox checked={false} onValueChange={valueChangeFn} borderRadius={borderRadiusMock} />
-		);
+		const {root} = create(<CheckBox checked={false} borderRadius={borderRadiusMock} />);
 		const ViewComponent = root.findByType(TouchableOpacity);
 		const {borderRadius} = ViewComponent.props.children.props.style;
 
 		expect(borderRadius).toBe(borderRadiusMock);
+	});
+
+	describe('hasnt border radius', () => {
+		const {root} = create(<CheckBox checked={false} />);
+		const ViewComponent = root.findByType(TouchableOpacity);
+		const {borderRadius} = ViewComponent.props.children.props.style;
+
+		expect(borderRadius).toBe(4);
 	});
 });

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -9,6 +9,7 @@ interface CheckBoxProps {
 	checkOnColor?: string;
 	checkOffColor?: string;
 	iconCheckColor?: string;
+	borderRadius?: number;
 	disabled?: boolean;
 }
 
@@ -21,12 +22,19 @@ const CheckBox = ({
 	checkOnColor = '#2979FF',
 	checkOffColor = '#939598',
 	iconCheckColor = '#FFF',
+	borderRadius,
 	disabled = false,
 	...props
 }: CheckBoxProps) => {
 	const isDisabled = disabled ? 0.6 : 1;
+	const hasBorderRadius = borderRadius ? borderRadius : getCheckBoxScale(customSize);
 
 	const styles = StyleSheet.create({
+		touchableOpacity: {
+			width: customSize,
+			height: customSize,
+			borderRadius: hasBorderRadius,
+		},
 		checkOn: {
 			display: 'flex',
 			justifyContent: 'center',
@@ -34,7 +42,7 @@ const CheckBox = ({
 			backgroundColor: checkOnColor,
 			width: customSize,
 			height: customSize,
-			borderRadius: getCheckBoxScale(customSize),
+			borderRadius: hasBorderRadius,
 			opacity: isDisabled,
 		},
 		checkOff: {
@@ -42,7 +50,7 @@ const CheckBox = ({
 			borderColor: checkOffColor,
 			width: customSize,
 			height: customSize,
-			borderRadius: getCheckBoxScale(customSize),
+			borderRadius: hasBorderRadius,
 			opacity: isDisabled,
 		},
 	});
@@ -50,7 +58,11 @@ const CheckBox = ({
 	const isChecked = checked ? styles.checkOn : styles.checkOff;
 
 	return (
-		<TouchableOpacity onPress={() => onValueChange()} disabled={disabled} activeOpacity={0.6}>
+		<TouchableOpacity
+			onPress={() => onValueChange()}
+			disabled={disabled}
+			activeOpacity={0.6}
+			style={styles.touchableOpacity}>
 			<View style={isChecked} {...props}>
 				{checked && <Icon color={iconCheckColor} size={customSize} />}
 			</View>

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -3,7 +3,7 @@ import {View, TouchableOpacity, StyleSheet} from 'react-native';
 import Icon from './icon/CheckedIcon';
 
 interface CheckBoxProps {
-	value: boolean;
+	checked: boolean;
 	onValueChange?: () => void;
 	customSize?: number;
 	checkOnColor?: string;
@@ -15,7 +15,7 @@ interface CheckBoxProps {
 export const getCheckBoxScale = (size: number): number => size / 9;
 
 const CheckBox = ({
-	value,
+	checked,
 	onValueChange = () => {},
 	customSize = 18,
 	checkOnColor = '#2979FF',
@@ -47,12 +47,12 @@ const CheckBox = ({
 		},
 	});
 
-	const isChecked = value ? styles.checkOn : styles.checkOff;
+	const isChecked = checked ? styles.checkOn : styles.checkOff;
 
 	return (
 		<TouchableOpacity onPress={() => onValueChange()} disabled={disabled} activeOpacity={0.6}>
 			<View style={isChecked} {...props}>
-				{value && <Icon color={iconCheckColor} size={customSize} />}
+				{checked && <Icon color={iconCheckColor} size={customSize} />}
 			</View>
 		</TouchableOpacity>
 	);

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import Icon from './icon/CheckedIcon';
+
+interface CheckBoxProps {
+	value: boolean;
+	onValueChange?: () => void;
+	customSize?: number;
+	checkOnColor?: string;
+	checkOffColor?: string;
+	iconCheckColor?: string;
+	disabled?: boolean;
+}
+
+export const getCheckBoxScale = (size: number): number => size / 9;
+
+const CheckBox = ({
+	value,
+	onValueChange = () => {},
+	customSize = 18,
+	checkOnColor = '#2979FF',
+	checkOffColor = '#939598',
+	iconCheckColor = '#FFF',
+	disabled = false,
+	...props
+}: CheckBoxProps) => {
+	const isDisabled = disabled ? 0.6 : 1;
+
+	const styles = StyleSheet.create({
+		checkOn: {
+			display: 'flex',
+			justifyContent: 'center',
+			alignItems: 'center',
+			backgroundColor: checkOnColor,
+			width: customSize,
+			height: customSize,
+			borderRadius: getCheckBoxScale(customSize),
+			opacity: isDisabled,
+		},
+		checkOff: {
+			borderWidth: getCheckBoxScale(customSize),
+			borderColor: checkOffColor,
+			width: customSize,
+			height: customSize,
+			borderRadius: getCheckBoxScale(customSize),
+			opacity: isDisabled,
+		},
+	});
+
+	const isChecked = value ? styles.checkOn : styles.checkOff;
+
+	return (
+		<TouchableOpacity onPress={() => onValueChange()} disabled={disabled} activeOpacity={0.6}>
+			<View style={isChecked} {...props}>
+				{value && <Icon color={iconCheckColor} size={customSize} />}
+			</View>
+		</TouchableOpacity>
+	);
+};
+
+export default CheckBox;

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import {base, grey, primary} from '../../theme/palette';
 import Icon from './icon/CheckedIcon';
 
 interface CheckBoxProps {
 	checked: boolean;
-	onValueChange?: () => void;
 	customSize?: number;
 	checkOnColor?: string;
 	checkOffColor?: string;
@@ -13,21 +13,19 @@ interface CheckBoxProps {
 	disabled?: boolean;
 }
 
-export const getCheckBoxScale = (size: number): number => size / 9;
+const getCheckBoxScale = (size: number, divisor: number): number => size / divisor;
 
 const CheckBox = ({
 	checked,
-	onValueChange = () => {},
-	customSize = 18,
-	checkOnColor = '#2979FF',
-	checkOffColor = '#939598',
-	iconCheckColor = '#FFF',
+	customSize = 16,
+	checkOnColor = primary.main,
+	checkOffColor = grey[500],
+	iconCheckColor = base.white,
 	borderRadius,
 	disabled = false,
 	...props
 }: CheckBoxProps) => {
-	const isDisabled = disabled ? 0.6 : 1;
-	const hasBorderRadius = borderRadius ? borderRadius : getCheckBoxScale(customSize);
+	const hasBorderRadius = !borderRadius ? getCheckBoxScale(customSize, 4) : borderRadius;
 
 	const styles = StyleSheet.create({
 		touchableOpacity: {
@@ -39,19 +37,17 @@ const CheckBox = ({
 			display: 'flex',
 			justifyContent: 'center',
 			alignItems: 'center',
-			backgroundColor: checkOnColor,
+			backgroundColor: !disabled ? checkOnColor : grey[200],
 			width: customSize,
 			height: customSize,
 			borderRadius: hasBorderRadius,
-			opacity: isDisabled,
 		},
 		checkOff: {
-			borderWidth: getCheckBoxScale(customSize),
-			borderColor: checkOffColor,
+			borderWidth: getCheckBoxScale(customSize, 16),
+			borderColor: !disabled ? checkOffColor : grey[200],
 			width: customSize,
 			height: customSize,
 			borderRadius: hasBorderRadius,
-			opacity: isDisabled,
 		},
 	});
 
@@ -59,7 +55,6 @@ const CheckBox = ({
 
 	return (
 		<TouchableOpacity
-			onPress={() => onValueChange()}
 			disabled={disabled}
 			activeOpacity={0.6}
 			style={styles.touchableOpacity}

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -62,10 +62,9 @@ const CheckBox = ({
 			onPress={() => onValueChange()}
 			disabled={disabled}
 			activeOpacity={0.6}
-			style={styles.touchableOpacity}>
-			<View style={isChecked} {...props}>
-				{checked && <Icon color={iconCheckColor} size={customSize} />}
-			</View>
+			style={styles.touchableOpacity}
+			{...props}>
+			<View style={isChecked}>{checked && <Icon color={iconCheckColor} size={customSize} />}</View>
 		</TouchableOpacity>
 	);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Text from './components/Text';
 import Avatar from './components/Avatar';
+import CheckBox from './components/CheckBox';
 
-export {Text, Avatar};
+export {Text, Avatar, CheckBox};

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,0 +1,62 @@
+import {
+	Alert,
+	Base,
+	Black,
+	Env,
+	Error,
+	GreyScale,
+	Primary,
+	Success,
+	Warning,
+	White,
+} from '../ts/interfaces/colors';
+
+const primary: Primary = {
+	main: '#2979FF',
+	dark: '#1759FF',
+	light: '#02BFFB',
+};
+const black: Black = {
+	main: '#2F2F2F',
+	dark: '#050505',
+};
+const white: White = {
+	main: '#E8EAF6',
+	dark: '#D0D3E3',
+	light: '#F4F5FB',
+};
+const grey: GreyScale = {
+	100: '#DDDFE2',
+	200: '#D5D7DB',
+	300: '#C4C6CC',
+	400: '#A8AAAC',
+	500: '#939598',
+	600: '#747679',
+	700: '#585858',
+};
+const base: Base = {
+	white: '#fff',
+	black: '#000',
+};
+const success: Success = {
+	main: '#1DB779',
+	dark: '#109D59',
+};
+const error: Error = {
+	main: '#FF4343',
+	dark: '#FF2A2A',
+};
+const warning: Warning = {
+	main: '#FF8D10',
+	dark: '#FF6E08',
+};
+const alert: Alert = {
+	main: '#FFCE17',
+	dark: '#FFBA0C',
+};
+const environment: Env = {
+	qa: '#1DB779',
+	beta: '#F13B70',
+};
+
+export {primary, black, white, grey, base, success, error, warning, alert, environment};

--- a/src/ts/interfaces/colors.ts
+++ b/src/ts/interfaces/colors.ts
@@ -1,0 +1,30 @@
+export interface GreyScale {
+	100: string;
+	200: string;
+	300: string;
+	400: string;
+	500: string;
+	600: string;
+	700: string;
+}
+export interface Env {
+	qa: string;
+	beta: string;
+}
+export interface Base {
+	black: string;
+	white: string;
+}
+export interface gamaColor {
+	main: string;
+	dark: string;
+}
+export interface Black extends gamaColor {}
+export interface Success extends gamaColor {}
+export interface Error extends gamaColor {}
+export interface Warning extends gamaColor {}
+export interface Alert extends gamaColor {}
+export interface Primary extends gamaColor {
+	light: string;
+}
+export interface White extends Primary {}

--- a/storybook/stories/CheckBox/CheckBox.stories.js
+++ b/storybook/stories/CheckBox/CheckBox.stories.js
@@ -15,6 +15,7 @@ storiesOf('CheckBox', module)
 			checkOnColor={color('checkOnColor', '#2979FF')}
 			checkOffColor={color('checkOffColor', '#939598')}
 			iconCheckColor={color('iconCheckColor', '#FFF')}
+			borderRadius={number('borderRadius', 2)}
 			disabled={boolean('disabld', false)}
 		/>
 	));

--- a/storybook/stories/CheckBox/CheckBox.stories.js
+++ b/storybook/stories/CheckBox/CheckBox.stories.js
@@ -3,16 +3,18 @@ import {storiesOf} from '@storybook/react-native';
 import {boolean, number, color} from '@storybook/addon-knobs';
 import CheckBox from '../../../src/components/CheckBox';
 import CenterView from '../CenterView';
+import {action} from '@storybook/addon-actions';
 
 storiesOf('CheckBox', module)
 	.addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
 	.add('default props', () => (
 		<CheckBox
-			value={boolean('value', {OFF: false}, false)}
+			value={boolean('value', true)}
+			onValueChange={action('onValueChange')}
 			customSize={number('customSize', 18)}
 			checkOnColor={color('checkOnColor', '#2979FF')}
 			checkOffColor={color('checkOffColor', '#939598')}
 			iconCheckColor={color('iconCheckColor', '#FFF')}
-			disabled={boolean('disabld', {OFF: false}, false)}
+			disabled={boolean('disabld', false)}
 		/>
 	));

--- a/storybook/stories/CheckBox/CheckBox.stories.js
+++ b/storybook/stories/CheckBox/CheckBox.stories.js
@@ -9,7 +9,7 @@ storiesOf('CheckBox', module)
 	.addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
 	.add('default props', () => (
 		<CheckBox
-			value={boolean('value', true)}
+			checked={boolean('checked', true)}
 			onValueChange={action('onValueChange')}
 			customSize={number('customSize', 18)}
 			checkOnColor={color('checkOnColor', '#2979FF')}

--- a/storybook/stories/CheckBox/CheckBox.stories.js
+++ b/storybook/stories/CheckBox/CheckBox.stories.js
@@ -11,11 +11,11 @@ storiesOf('CheckBox', module)
 		<CheckBox
 			checked={boolean('checked', true)}
 			onValueChange={action('onValueChange')}
-			customSize={number('customSize', 18)}
+			customSize={number('customSize', 16)}
 			checkOnColor={color('checkOnColor', '#2979FF')}
 			checkOffColor={color('checkOffColor', '#939598')}
 			iconCheckColor={color('iconCheckColor', '#FFF')}
-			borderRadius={number('borderRadius', 2)}
+			borderRadius={number('borderRadius', 4)}
 			disabled={boolean('disabld', false)}
 		/>
 	));

--- a/storybook/stories/CheckBox/CheckBox.stories.js
+++ b/storybook/stories/CheckBox/CheckBox.stories.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react-native';
+import {boolean, number, color} from '@storybook/addon-knobs';
+import CheckBox from '../../../src/components/CheckBox';
+import CenterView from '../CenterView';
+
+storiesOf('CheckBox', module)
+	.addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
+	.add('default props', () => (
+		<CheckBox
+			value={boolean('value', {OFF: false}, false)}
+			customSize={number('customSize', 18)}
+			checkOnColor={color('checkOnColor', '#2979FF')}
+			checkOffColor={color('checkOffColor', '#939598')}
+			iconCheckColor={color('iconCheckColor', '#FFF')}
+			disabled={boolean('disabld', {OFF: false}, false)}
+		/>
+	));

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -1,2 +1,3 @@
 import './Button/Button.stories';
 import './Avatar/Avatar.stories';
+import './CheckBox/CheckBox.stories';

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -6,9 +6,14 @@
 function loadStories() {
 	require('./stories/Avatar/Avatar.stories');
 	require('./stories/Button/Button.stories');
+	require('./stories/CheckBox/CheckBox.stories');
 }
 
-const stories = ['./stories/Avatar/Avatar.stories', './stories/Button/Button.stories'];
+const stories = [
+	'./stories/Avatar/Avatar.stories',
+	'./stories/Button/Button.stories',
+	'./stories/CheckBox/CheckBox.stories.js',
+];
 
 module.exports = {
 	loadStories,

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -12,7 +12,7 @@ function loadStories() {
 const stories = [
 	'./stories/Avatar/Avatar.stories',
 	'./stories/Button/Button.stories',
-	'./stories/CheckBox/CheckBox.stories.js',
+	'./stories/CheckBox/CheckBox.stories',
 ];
 
 module.exports = {


### PR DESCRIPTION
**Descripción**

**Contexto**
No contamos en la librería de apps con el componente checkbox y la consecuencia de esto es que tengamos un componente en cada apps, repitiendo codigo , con la posibilidad de que se generen distintos bugs y que sea dificil de mantener y escalar

**Necesidad**
contar con un componente reutilizable que podamos usar en las distintas apps de Janis teniendo un codigo único para facilitar la escalabilidad y soporte.

 

https://www.figma.com/file/ZWLyF29DMLh5ywkBnuHVZi/Janis-Delivery-App---DEV?node-id=0%3A154&t=nPsqdItRCU5bkmhp-0

**Acceptance criteria**



**Analisis funcional**

es imposible contar con react-native.CheckBox nativo porque no se le pueden asignar colores, entonces debemos construir uno con componente Image como icono cuando este chequeado.

el contenedor de checkbox será construido con componentes navitos de react-native.

https://docs.expo.dev/ui-programming/implementing-a-checkbox/



Prop | Default | Requerido | Tipo | Obs.
-- | -- | -- | -- | --
checked | - | true | boolean | -
customSize | 16 | FALSE | number | -
checkOnColor | primary.main | FALSE | string | -
checkOffColor | grey[500] | FALSE | string | -
iconCheckColor | base.white | FALSE | string | -
borderRadius | - | FALSE | number | se agrega solamente si recibe valor por esta prop
disabled | false | FALSE | boolean | -

