### PR TITLE
componente reutilizable terminado

### DIFF
--- a/src/components/StatusChip/__snapshots__/index.test.tsx.snap
+++ b/src/components/StatusChip/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusChip component render correct a valid component is passed 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#fff",
+      "borderColor": "#C4C6CC",
+      "borderRadius": 12,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "height": 24,
+      "paddingLeft": 12,
+      "paddingRight": 12,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "fontFamily": "Roboto",
+        "fontSize": 16,
+      }
+    }
+  >
+    Custom component
+  </Text>
+</View>
+`;
+
+exports[`StatusChip component render correct if a color is passed 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#2979FF",
+      "borderColor": "#2979FF",
+      "borderRadius": 12,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "height": 24,
+      "paddingLeft": 12,
+      "paddingRight": 12,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#fff",
+        "fontFamily": "Roboto",
+        "fontSize": 15,
+        "fontWeight": "900",
+        "lineHeight": 18,
+        "textAlign": "center",
+      }
+    }
+  >
+    Delivered
+  </Text>
+</View>
+`;
+
+exports[`StatusChip component render correct text is passed 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#fff",
+      "borderColor": "#C4C6CC",
+      "borderRadius": 12,
+      "borderWidth": 1,
+      "flexDirection": "row",
+      "height": 24,
+      "paddingLeft": 12,
+      "paddingRight": 12,
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "color": "#2979FF",
+        "fontFamily": "Roboto",
+        "fontSize": 15,
+        "fontWeight": "900",
+        "lineHeight": 18,
+        "textAlign": "center",
+      }
+    }
+  >
+    Partially delivered
+  </Text>
+</View>
+`;

--- a/src/components/StatusChip/index.test.tsx
+++ b/src/components/StatusChip/index.test.tsx
@@ -1,0 +1,36 @@
+import 'react-native';
+import React from 'react';
+import {create} from 'react-test-renderer';
+import StatusChip from './index';
+import Text from '../Text';
+import {primary} from '../../theme/palette';
+
+describe('StatusChip component', () => {
+	describe('return error because is not a valid children', () => {
+		it('undefined children', () => {
+			const {toJSON} = create(<StatusChip />);
+			expect(toJSON()).toBeNull();
+		});
+	});
+
+	describe('render correct', () => {
+		it('text is passed', () => {
+			const {toJSON} = create(<StatusChip>Partially delivered</StatusChip>);
+			expect(toJSON()).toMatchSnapshot();
+		});
+
+		it('if a color is passed', () => {
+			const {toJSON} = create(<StatusChip color={primary.main}>Delivered</StatusChip>);
+			expect(toJSON()).toMatchSnapshot();
+		});
+
+		it('a valid component is passed', () => {
+			const {toJSON} = create(
+				<StatusChip>
+					<Text>Custom component</Text>
+				</StatusChip>
+			);
+			expect(toJSON()).toMatchSnapshot();
+		});
+	});
+});

--- a/src/components/StatusChip/index.tsx
+++ b/src/components/StatusChip/index.tsx
@@ -1,0 +1,47 @@
+import React, {ReactElement, isValidElement} from 'react';
+import {StyleSheet, Text, ViewProps, View} from 'react-native';
+import {base, grey, primary} from '../../theme/palette';
+
+interface StatusChipProps extends ViewProps {
+	children?: ReactElement | string;
+	color?: string;
+}
+
+const StatusChip = ({children, color, ...props}: StatusChipProps) => {
+	const isString = typeof children === 'string';
+	const isCustomComponent = isValidElement(children);
+
+	if (!children || (!isString && !isCustomComponent)) {
+		return null;
+	}
+
+	const styles = StyleSheet.create({
+		ViewStyles: {
+			height: 24,
+			flexDirection: 'row',
+			alignItems: 'center',
+			paddingLeft: 12,
+			paddingRight: 12,
+			borderRadius: 12,
+			backgroundColor: color ?? base.white,
+			borderWidth: 1,
+			borderColor: color ?? grey['300'],
+		},
+		TextStyles: {
+			fontSize: 15,
+			lineHeight: 18,
+			fontFamily: 'Roboto',
+			fontWeight: '900',
+			textAlign: 'center',
+			color: color ? base.white : primary.main,
+		},
+	});
+
+	return (
+		<View style={styles.ViewStyles} {...props}>
+			{isCustomComponent ? children : <Text style={styles.TextStyles}>{children}</Text>}
+		</View>
+	);
+};
+
+export default StatusChip;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import Text from './components/Text';
 import Avatar from './components/Avatar';
 import CheckBox from './components/CheckBox';
 import Image from './components/Image';
+import StatusChip from './components/StatusChip';
 
-export {Text, Avatar, CheckBox, Image};
+export {Text, Avatar, CheckBox, Image, StatusChip};

--- a/storybook/stories/StatusChip/StatusChip.stories.js
+++ b/storybook/stories/StatusChip/StatusChip.stories.js
@@ -1,0 +1,63 @@
+import {storiesOf} from '@storybook/react-native';
+import {text, select, number, color} from '@storybook/addon-knobs';
+import StatusChip from '../../../src/components/StatusChip';
+import Text from '../Text';
+import CenterView from '../CenterView';
+import React from 'react';
+
+const fontFamilies = [
+	'normal',
+	'notoserif',
+	'sans-serif',
+	'sans-serif-light',
+	'sans-serif-thin',
+	'sans-serif-condensed',
+	'sans-serif-medium',
+	'serif',
+	'Roboto',
+	'monospace',
+];
+const fontWeight = [
+	'normal',
+	'bold',
+	'100',
+	'200',
+	'300',
+	'400',
+	'500',
+	'600',
+	'700',
+	'800',
+	'900',
+];
+
+storiesOf('StatusChip', module)
+	.addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
+	.add('passing it text', () => (
+		<StatusChip color={select('color', ['#2979FF', '#1DB779', ''], '')}>
+			Partially delivered
+		</StatusChip>
+	))
+	.add('passing it a custom component', () => (
+		<StatusChip color={select('color', ['#2979FF', '#1DB779', null], null)}>
+			<Text
+				fontSize={number('fontSize', 16)}
+				color={color('text color', '#000000')}
+				fontFamily={select('fontFamily', fontFamilies, 'Roboto')}
+				fontStyle={select('fontStyle', ['normal', 'italic'], 'normal')}
+				fontWeight={select('fontWeight', fontWeight, 'normal')}
+				letterSpacing={number('letterSpacing', 0)}
+				textDecorationLine={select(
+					'textDecorationLine',
+					['none', 'underline', 'line-through', 'underline line-through'],
+					'none'
+				)}
+				textTransform={select(
+					'textTransform',
+					['none', 'uppercase', 'lowercase', 'capitalize'],
+					'none'
+				)}>
+				{text('text', 'Janis Commerce')}
+			</Text>
+		</StatusChip>
+	));

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -2,3 +2,4 @@ import './Avatar/Avatar.stories';
 import './CheckBox/CheckBox.stories';
 import './Image/Image.stories';
 import './Text/Text.stories';
+import './StatusChip/StatusChip.stories';

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -7,6 +7,7 @@ function loadStories() {
 	require('./stories/Avatar/Avatar.stories');
 	require('./stories/CheckBox/CheckBox.stories');
 	require('./stories/Image/Image.stories');
+	require('./stories/StatusChip/StatusChip.stories');
 	require('./stories/Text/Text.stories');
 }
 
@@ -14,6 +15,7 @@ const stories = [
 	'./stories/Avatar/Avatar.stories',
 	'./stories/CheckBox/CheckBox.stories',
 	'./stories/Image/Image.stories',
+	'./stories/StatusChip/StatusChip.stories',
 	'./stories/Text/Text.stories',
 ];
 


### PR DESCRIPTION
**LINK DE TICKET:**
https://janiscommerce.atlassian.net/browse/JUIP-94

**DESCRIPCIÓN DEL REQUERIMIENTO:**

Contexto
No contamos en la librería de apps con el componente status chip y la consecuencia de esto es que tengamos un componente en cada apps, repitiendo codigo , con la posibilidad de que se generen distintos bugs y que sea dificil de mantener y escalar

Necesidad
contar con un componente reutilizable que podamos usar en las distintas apps de Janis teniendo un codigo único para facilitar la escalabilidad y soporte.

Acceptance criteria


Debe aceptar un color para aplicar como background y borde de 1px con el mismo color. En caso de no tener, el default seria blanco y se aplicaria border de 1px en gris (a definir el gris) para diferenciar.

Debe aceptar un texto a mostrar

Los estilos a aplicar de base, serian los bordes redondeados. 

Se debe destructurar props para poder extender estilos
Si el children es un string, se renderiza el componente Text con estilos por default

Si el children es un componente valido de REact, se renderiza el mismo

Estilos por default del texto
font size 15px

font weight bold

color #fff

**DESCRIPCIÓN DE LA SOLUCIÓN:**

Crear el componente status chip.

Crear test que validen el componente.

Crear su storyBook. 

**CÓMO SE PUEDE PROBAR?**
Clonar e instalar el Repo de UI-Native

Correr los siguientes 3 comandos en tres pestañas diferentes de la termina

npm run start
npm run android
npm run storybook

Se debe abrir la app en el emulador con storybooks y el navegador en la url http://localhost:7007/ donde se podrá probar
el comportamiento del componente

Para linkear el componente con un proyecto, seguir la siguiente documentación
https://fizzmod.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI

SCREENSHOTS:
![Screenshot_1689025801](https://github.com/janis-commerce/ui-native/assets/69169114/79ddf226-bd04-4343-b29b-635bf83237dd)
