### PR TITLE
Juip-110-radio-button

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -14,7 +14,7 @@ global.STORIES = [
     directory: "./storybook/stories",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      "^\\.[\\\\/](?:storybook[\\\\/]stories(?:[\\\\/](?!\\.)(?:(?:(?!(?:^|[\\\\/])\\.).)*?)[\\\\/]|[\\\\/]|$)(?!\\.)(?=.)[^\\\\/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
+      "^\\.[\\\\/](?:storybook\\/stories(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
   },
 ];
 
@@ -50,6 +50,7 @@ const getStories = () => {
     "./storybook/stories/Avatar/Avatar.stories.js": require("../storybook/stories/Avatar/Avatar.stories.js"),
     "./storybook/stories/CheckBox/CheckBox.stories.js": require("../storybook/stories/CheckBox/CheckBox.stories.js"),
     "./storybook/stories/Image/Image.stories.js": require("../storybook/stories/Image/Image.stories.js"),
+    "./storybook/stories/RadioButton/RadioButton.stories.js": require("../storybook/stories/RadioButton/RadioButton.stories.js"),
     "./storybook/stories/Text/Text.stories.js": require("../storybook/stories/Text/Text.stories.js"),
   };
 };

--- a/src/components/RadioButton/index.test.tsx
+++ b/src/components/RadioButton/index.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {create} from 'react-test-renderer';
+import RadioButton from './index';
+import Text from '../Text';
+import {TouchableOpacity} from 'react-native';
+
+describe('radioButton component', () => {
+	it('not rendered when not receive a valid text', () => {
+		const {toJSON} = create(<RadioButton children="" />);
+
+		expect(toJSON()).toStrictEqual(null);
+	});
+
+	it('should render correctly when receives a valid text as child', () => {
+		const {toJSON} = create(<RadioButton direction="row-reverse">Example text</RadioButton>);
+		expect(toJSON()).toBeTruthy();
+	});
+
+	it('should render correctly when receives a valid child', () => {
+		const child = <Text>valid child</Text>;
+
+		const {toJSON} = create(<RadioButton>{child}</RadioButton>);
+		expect(toJSON()).toBeTruthy();
+	});
+
+	it('should execute the onPress function when it is received', () => {
+		const onPressFunc = jest.fn();
+
+		const {root} = create(<RadioButton onPress={onPressFunc}>Example text</RadioButton>);
+
+		const [pressableText] = root.findAllByType(TouchableOpacity);
+
+		pressableText.props.onPress();
+
+		expect(onPressFunc).toBeCalled();
+	});
+});

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import Text from '../Text';
+import CheckBox from '../CheckBox';
+
+const directions = ['row', 'row-reverse'] as const;
+
+type directionType = (typeof directions)[number];
+
+const CheckSizeValues = {
+	sm: 16,
+	md: 24,
+	lg: 32,
+};
+
+type sizeType = typeof CheckSizeValues;
+type sizeKeys = keyof sizeType;
+
+interface RadioButtonProps {
+	children: React.ReactNode | string;
+	selected?: boolean;
+	onPress?: () => {};
+	direction?: directionType;
+	disabled?: boolean;
+	checkSize?: sizeKeys;
+}
+
+const RadioButton = ({
+	children,
+	onPress,
+	selected = false,
+	direction = 'row',
+	checkSize = 'sm',
+	disabled = false,
+	...props
+}: RadioButtonProps) => {
+	if (!children) {
+		return null;
+	}
+
+	const {container, row, reverseRow, checkToLeft} = styles;
+	const isStringChild = typeof children === 'string';
+	const reverseDirection = direction === 'row-reverse';
+	const customSize = CheckSizeValues[checkSize];
+
+	return (
+		<View style={[container, reverseDirection ? {...reverseRow} : {...row}]} {...props}>
+			<TouchableOpacity
+				onPress={onPress}
+				disabled={disabled}
+				style={reverseDirection && checkToLeft}>
+				{isStringChild ? <Text>{children}</Text> : children}
+			</TouchableOpacity>
+			<CheckBox
+				checked={selected}
+				disabled={disabled}
+				customSize={customSize}
+				borderRadius={customSize / 2}
+			/>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		alignItems: 'center',
+		paddingHorizontal: 16,
+		marginVertical: 10,
+		height: 'auto',
+	},
+
+	row: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+	},
+	reverseRow: {
+		flexDirection: 'row-reverse',
+		justifyContent: 'flex-end',
+	},
+	checkToLeft: {
+		marginLeft: 15,
+	},
+});
+
+export default RadioButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import Text from './components/Text';
 import Avatar from './components/Avatar';
 import CheckBox from './components/CheckBox';
 import Image from './components/Image';
+import RadioButton from './components/RadioButton';
 
-export {Text, Avatar, CheckBox, Image};
+export {Text, Avatar, CheckBox, Image, RadioButton};

--- a/storybook/stories/RadioButton/RadioButton.stories.js
+++ b/storybook/stories/RadioButton/RadioButton.stories.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import RadioButton from '../../../src/components/RadioButton';
+import Image from '../../../src/components/Image';
+
+export default {
+	title: 'RadioButton',
+	argTypes: {
+		checkSize: {
+			options: ['sm', 'md', 'lg'],
+			control: {type: 'select'},
+		},
+		direction: {
+			options: ['row', 'row-reverse'],
+			control: {type: 'select'},
+		},
+		selected: {
+			options: [true, false],
+			control: {type: 'radio'},
+		},
+		disabled: {
+			options: [true, false],
+			control: {type: 'radio'},
+		},
+	},
+};
+
+export const WithTextChild = (props) => <RadioButton {...props}>option 1</RadioButton>;
+
+WithTextChild.storyName = 'with text child';
+
+WithTextChild.args = {
+	checkSize: 'sm',
+	direction: 'row',
+	selected: true,
+	disabled: false,
+};
+
+export const WithChildComponent = (props) => (
+	<RadioButton {...props}>
+		<Image
+			source={{
+				uri: 'https://avatars.githubusercontent.com/u/49998302?s=200&v=4',
+				width: 80,
+				height: 80,
+			}}
+		/>
+	</RadioButton>
+);
+
+WithChildComponent.storyName = 'with child component';
+
+WithChildComponent.args = {
+	checkSize: 'lg',
+	direction: 'row-reverse',
+	selected: false,
+	disabled: false,
+};


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/JUIP-76

DESCRIPCIÓN DEL REQUERIMIENTO: *

Se necesita incluir un componente radioButton para poder implementarlo en las 3 apps.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se agregó el componente radioButton. 
Este componente puede recibir cómo children un texto o un componente para renderizar y en caso de no recibirlo retorna null.  También requiere el uso de un booleano, pero en caso de no recibirlo, por defecto su valor es false.


SCREENSHOTS:
![Captura desde 2023-07-31 16-53-13](https://github.com/janis-commerce/ui-native/assets/75044106/68cca8d4-f948-440c-a57b-409550a8faf5)
![Captura desde 2023-07-31 16-53-24](https://github.com/janis-commerce/ui-native/assets/75044106/485b8f92-d22e-4799-b8f4-b6c6bda6f9c6)
