### PR TITLE
Añadir compatibilidad de componentes con styled components

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -14,7 +14,7 @@ global.STORIES = [
     directory: "./storybook/stories",
     files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      "^\\.[\\\\/](?:storybook\\/stories(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
+      "^\\.[\\\\/](?:storybook[\\\\/]stories(?:[\\\\/](?!\\.)(?:(?:(?!(?:^|[\\\\/])\\.).)*?)[\\\\/]|[\\\\/]|$)(?!\\.)(?=.)[^\\\\/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
   },
 ];
 
@@ -49,6 +49,7 @@ const getStories = () => {
   return {
     "./storybook/stories/Avatar/Avatar.stories.js": require("../storybook/stories/Avatar/Avatar.stories.js"),
     "./storybook/stories/CheckBox/CheckBox.stories.js": require("../storybook/stories/CheckBox/CheckBox.stories.js"),
+    "./storybook/stories/DesignStystem/Colors.stories.js": require("../storybook/stories/DesignStystem/Colors.stories.js"),
     "./storybook/stories/Image/Image.stories.js": require("../storybook/stories/Image/Image.stories.js"),
     "./storybook/stories/Input/Input.stories.js": require("../storybook/stories/Input/Input.stories.js"),
     "./storybook/stories/Loading/Loading.stories.js": require("../storybook/stories/Loading/Loading.stories.js"),

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -21,7 +21,7 @@ export interface AvatarProps {
 	customSize?: number;
 	imageUrl?: string;
 	onErrorImg?: () => void;
-	style?: ViewStyle[];
+	style?: ViewStyle;
 }
 
 const styles = StyleSheet.create({
@@ -46,7 +46,7 @@ const Avatar = ({
 	placeholder,
 	customSize,
 	onErrorImg,
-	style = [],
+	style,
 	...props
 }: AvatarProps) => {
 	const [showInitials, setShowInitials] = useState(false);
@@ -74,7 +74,7 @@ const Avatar = ({
 					height: getSize(size, customSize),
 					width: getSize(size, customSize),
 				},
-				...style,
+				style,
 			]}
 			{...props}>
 			{!!imageUrl && !showInitials && (

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, ViewStyle} from 'react-native';
 import Image from '../Image';
 import Text from '../Text';
 import {formatPlaceholder} from './utils/formatPlaceholder/index';
@@ -21,6 +21,7 @@ export interface AvatarProps {
 	customSize?: number;
 	imageUrl?: string;
 	onErrorImg?: () => void;
+	style?: ViewStyle[];
 }
 
 const styles = StyleSheet.create({
@@ -45,6 +46,7 @@ const Avatar = ({
 	placeholder,
 	customSize,
 	onErrorImg,
+	style = [],
 	...props
 }: AvatarProps) => {
 	const [showInitials, setShowInitials] = useState(false);
@@ -72,6 +74,7 @@ const Avatar = ({
 					height: getSize(size, customSize),
 					width: getSize(size, customSize),
 				},
+				...style,
 			]}
 			{...props}>
 			{!!imageUrl && !showInitials && (

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -11,7 +11,7 @@ interface CheckBoxProps {
 	iconCheckColor?: string;
 	borderRadius?: number;
 	disabled?: boolean;
-	style?: ViewStyle[];
+	style?: ViewStyle;
 }
 
 const getCheckBoxScale = (size: number, divisor: number): number => size / divisor;
@@ -24,7 +24,7 @@ const CheckBox = ({
 	iconCheckColor = base.white,
 	borderRadius,
 	disabled = false,
-	style = [],
+	style,
 	...props
 }: CheckBoxProps) => {
 	const hasBorderRadius = !borderRadius ? getCheckBoxScale(customSize, 4) : borderRadius;
@@ -59,7 +59,7 @@ const CheckBox = ({
 		<TouchableOpacity
 			disabled={disabled}
 			activeOpacity={0.6}
-			style={[styles.touchableOpacity, ...style]}
+			style={[styles.touchableOpacity, style]}
 			{...props}>
 			<View style={isChecked}>{checked && <Icon color={iconCheckColor} size={customSize} />}</View>
 		</TouchableOpacity>

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import {View, TouchableOpacity, StyleSheet, ViewStyle} from 'react-native';
 import {base, grey, primary} from '../../theme/palette';
 import Icon from './icon/CheckedIcon';
 
@@ -11,6 +11,7 @@ interface CheckBoxProps {
 	iconCheckColor?: string;
 	borderRadius?: number;
 	disabled?: boolean;
+	style?: ViewStyle[];
 }
 
 const getCheckBoxScale = (size: number, divisor: number): number => size / divisor;
@@ -23,6 +24,7 @@ const CheckBox = ({
 	iconCheckColor = base.white,
 	borderRadius,
 	disabled = false,
+	style = [],
 	...props
 }: CheckBoxProps) => {
 	const hasBorderRadius = !borderRadius ? getCheckBoxScale(customSize, 4) : borderRadius;
@@ -57,7 +59,7 @@ const CheckBox = ({
 		<TouchableOpacity
 			disabled={disabled}
 			activeOpacity={0.6}
-			style={styles.touchableOpacity}
+			style={[styles.touchableOpacity, ...style]}
 			{...props}>
 			<View style={isChecked}>{checked && <Icon color={iconCheckColor} size={customSize} />}</View>
 		</TouchableOpacity>

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,5 @@
 import React, {LegacyRef, useEffect, useState} from 'react';
-import {TextInput, StyleSheet, View, Text, KeyboardType, StyleProp, TextStyle} from 'react-native';
+import {TextInput, StyleSheet, View, Text, KeyboardType, TextStyle} from 'react-native';
 import {
 	Status,
 	getBorderColor,

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,5 @@
 import React, {LegacyRef, useEffect, useState} from 'react';
-import {TextInput, StyleSheet, View, Text, KeyboardType, ViewStyle} from 'react-native';
+import {TextInput, StyleSheet, View, Text, KeyboardType, StyleProp, TextStyle} from 'react-native';
 import {
 	Status,
 	getBorderColor,
@@ -37,7 +37,7 @@ interface InputProps {
 	onSubmitEditing?: () => void;
 	onFocus?: () => void;
 	onBlur?: () => void;
-	style?: ViewStyle;
+	style?: StyleProp<TextStyle>;
 }
 
 const Input = React.forwardRef<TextInput, InputProps>(

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -37,7 +37,7 @@ interface InputProps {
 	onSubmitEditing?: () => void;
 	onFocus?: () => void;
 	onBlur?: () => void;
-	style?: StyleProp<TextStyle>;
+	style?: TextStyle;
 }
 
 const Input = React.forwardRef<TextInput, InputProps>(

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,5 +1,5 @@
 import React, {LegacyRef, useEffect, useState} from 'react';
-import {TextInput, StyleSheet, View, Text, KeyboardType} from 'react-native';
+import {TextInput, StyleSheet, View, Text, KeyboardType, ViewStyle} from 'react-native';
 import {
 	Status,
 	getBorderColor,
@@ -37,6 +37,7 @@ interface InputProps {
 	onSubmitEditing?: () => void;
 	onFocus?: () => void;
 	onBlur?: () => void;
+	style?: ViewStyle;
 }
 
 const Input = React.forwardRef<TextInput, InputProps>(
@@ -56,6 +57,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
 			onSubmitEditing = () => {},
 			onFocus = () => {},
 			onBlur = () => {},
+			style,
 			...props
 		}: InputProps,
 		ref: LegacyRef<TextInput>
@@ -135,7 +137,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
 				<View style={styles.inputWrapper}>
 					{isLabelVisible && <Text style={styles.label}>{label}</Text>}
 					<TextInput
-						style={styles.input}
+						style={[styles.input, style]}
 						ref={ref}
 						onFocus={onFocusHandler}
 						onBlur={onBlurHandler}

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, FC} from 'react';
-import {StyleSheet, View, Animated, Easing, ColorValue} from 'react-native';
+import {StyleSheet, View, Animated, Easing, ColorValue, ViewStyle} from 'react-native';
 import {primary, white} from '../../theme/palette';
 
 interface Params {
@@ -13,6 +13,7 @@ interface Props {
 	size?: number;
 	duration?: number;
 	children?: React.ReactNode | null;
+	style?: ViewStyle[];
 }
 
 const startRotationAnimation = ({duration, rotationDegree, timingAnimation}: Params): void =>
@@ -31,6 +32,7 @@ const Loading: FC<Props> = ({
 	size = 64,
 	duration = 1000,
 	children = null,
+	style = [],
 	...props
 }) => {
 	const rotationDegree = useRef(new Animated.Value(0)).current;
@@ -81,7 +83,7 @@ const Loading: FC<Props> = ({
 	}
 
 	return (
-		<View style={styles.container} {...props}>
+		<View style={[styles.container, ...style]} {...props}>
 			<Animated.View style={{...styles.spinner, ...animationSpinnerStyle}} />
 			{children}
 		</View>

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 	size?: number;
 	duration?: number;
 	children?: React.ReactNode | null;
-	style?: ViewStyle[];
+	style?: ViewStyle;
 }
 
 const startRotationAnimation = ({duration, rotationDegree, timingAnimation}: Params): void =>
@@ -32,7 +32,7 @@ const Loading: FC<Props> = ({
 	size = 64,
 	duration = 1000,
 	children = null,
-	style = [],
+	style,
 	...props
 }) => {
 	const rotationDegree = useRef(new Animated.Value(0)).current;
@@ -83,7 +83,7 @@ const Loading: FC<Props> = ({
 	}
 
 	return (
-		<View style={[styles.container, ...style]} {...props}>
+		<View style={[styles.container, style]} {...props}>
 			<Animated.View style={{...styles.spinner, ...animationSpinnerStyle}} />
 			{children}
 		</View>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ import Svg from './components/Svg';
 import Loading from './components/Loading';
 import StatusChip from './components/StatusChip';
 import Input from './components/Input';
+import {palette} from './theme/palette';
 
-export {Text, Avatar, CheckBox, Image, Loading, Svg, StatusChip, Input};
+export {Text, Avatar, CheckBox, Image, Loading, Svg, StatusChip, Input, palette};


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/JUIP-115

DESCRIPCIÓN DEL REQUERIMIENTO:

Contexto

Actualmente, al intentar utilizar el componente con styled components, al ser vinculado a alguna de las tres apps, esto no es posible

Necesidad

Se requiere hacer los componentes, que sean necesarios, compatibles para ser estilizados con styled components

DESCRIPCIÓN DE LA SOLUCIÓN:

Se le agregó la prop style a los componentes que sea posible editar los estilos para que, de esta manera, se los pueda estilizar con styled components

CÓMO SE PUEDE PROBAR?
Clonar e instalar el Repo de UI-Native

Linkear el componente con un proyecto, seguir la siguiente documentación
https://fizzmod.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI

Luego, se deberá probar que los distintos componentes modificados sean compatibles para editar con styled components
