### PR TITLE
agregar componente lista

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
 		'react/static-property-placement': 'off',
 		'react/jsx-props-no-spreading': 'off',
 		'no-param-reassign': 'off',
+		'no-shadow': 'off',
 		'no-console': 'error',
 	},
 };

--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -54,6 +54,7 @@ const getStories = () => {
 		'./storybook/stories/DesignStystem/Icons.stories.js': require('../storybook/stories/DesignStystem/Icons.stories.js'),
 		'./storybook/stories/Image/Image.stories.js': require('../storybook/stories/Image/Image.stories.js'),
 		'./storybook/stories/Input/Input.stories.js': require('../storybook/stories/Input/Input.stories.js'),
+		'./storybook/stories/List/List.stories.js': require('../storybook/stories/List/List.stories.js'),
 		'./storybook/stories/Loading/Loading.stories.js': require('../storybook/stories/Loading/Loading.stories.js'),
 		'./storybook/stories/LoadingFullScreen/LoadingFullScreen.stories.js': require('../storybook/stories/LoadingFullScreen/LoadingFullScreen.stories.js'),
 		'./storybook/stories/ProgressBar/ProgressBar.stories.js': require('../storybook/stories/ProgressBar/ProgressBar.stories.js'),

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -19,7 +19,6 @@ import {
 	showStatusMessage,
 } from './utils';
 
-// eslint-disable-next-line no-shadow
 export enum keyboardTypes {
 	default = 'default',
 	numberPad = 'number-pad',

--- a/src/components/List/index.test.tsx
+++ b/src/components/List/index.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {create} from 'react-test-renderer';
+import {Text, View} from 'react-native';
+import List, {TypeList} from './';
+
+const data = [
+	{id: 1, nombre: 'nombre1'},
+	{id: 2, nombre: 'nombre2'},
+];
+
+const renderComponent = ({item}) => (
+	<View key={item.id}>
+		<Text>{item.nombre}</Text>
+	</View>
+);
+
+describe('List component', () => {
+	describe('returns null when ', () => {
+		it('data is not correct', () => {
+			const {toJSON} = create(<List data={undefined} renderComponent={renderComponent} />);
+			expect(toJSON()).toBeNull();
+		});
+	});
+
+	describe('render correctlt when', () => {
+		it('data is array type and type is flatList per default', () => {
+			const {toJSON} = create(<List data={data} renderComponent={renderComponent} />);
+			expect(toJSON()).toBeTruthy();
+		});
+
+		it('data is array type and type is scrollView', () => {
+			const {toJSON} = create(
+				<List data={data} type={TypeList.ScrollView} renderComponent={renderComponent} />
+			);
+			expect(toJSON()).toBeTruthy();
+		});
+	});
+});

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,0 +1,34 @@
+import React, {FC} from 'react';
+import {FlatList, ScrollView, FlatListProps, ScrollViewProps} from 'react-native';
+
+type TypeData = string | number | object | [] | React.ReactElement;
+type RCProps = {
+	item: TypeData;
+	index: number;
+};
+type TypeRenderComponent = ({item, index}: RCProps) => React.ReactElement;
+export enum TypeList {
+	FlatList = 'flatList',
+	ScrollView = 'scrollView',
+}
+interface ListProps {
+	data: TypeData[] | undefined;
+	renderComponent: TypeRenderComponent;
+	type?: TypeList;
+}
+type MergedProps = ListProps & (FlatListProps<TypeData> | ScrollViewProps);
+
+const List: FC<MergedProps> = ({data, renderComponent, type = TypeList.FlatList, ...props}) => {
+	if (!data?.length) {
+		return null;
+	}
+
+	const FlatListComponent = () => <FlatList data={data} renderItem={renderComponent} {...props} />;
+	const ScrollViewComponent = () => (
+		<ScrollView {...props}>{data.map((item, index) => renderComponent({item, index}))}</ScrollView>
+	);
+
+	return type === TypeList.FlatList ? <FlatListComponent /> : <ScrollViewComponent />;
+};
+
+export default List;

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -11,6 +11,7 @@ export enum TypeList {
 	FlatList = 'flatList',
 	ScrollView = 'scrollView',
 }
+
 interface ListProps {
 	data: TypeData[] | undefined;
 	renderComponent: TypeRenderComponent;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -6,7 +6,6 @@ import ChevronIcon from './Components/Icons/Chevron';
 import DeleteIcon from './Components/Icons/Delete';
 import Dropdown from './Components/Dropdown';
 
-// eslint-disable-next-line no-shadow
 enum KeyboardTypes {
 	Default = 'default',
 	NumberPad = 'number-pad',

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from './components/SwipeUp/childComponents';
 import Carousel from './components/Carousel';
 import ProgressBar from './components/ProgressBar';
+import List from './components/List';
 
 export {
 	Text,
@@ -40,4 +41,5 @@ export {
 	SwipeUpView,
 	Carousel,
 	ProgressBar,
+	List,
 };

--- a/storybook/stories/List/List.stories.js
+++ b/storybook/stories/List/List.stories.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import List from '../../../src/components/List';
+import {StyleSheet, Text, View} from 'react-native';
+import {white} from '../../../src/theme/palette';
+
+export default {
+	title: 'Components/List',
+	argTypes: {
+		type: {
+			options: ['flatList', 'scrollView'],
+			control: {type: 'select'},
+		},
+	},
+};
+
+const fakeData = [
+	{
+		id: 'bd7acbea-c1b1-46c2-aed5-3ad53abb28ba',
+		title: 'First Item',
+	},
+	{
+		id: '3ac68afc-c605-48d3-a4f8-fbd91aa97f63',
+		title: 'Second Item',
+	},
+	{
+		id: '58694a0f-3da1-471f-bd96-145571e29d72',
+		title: 'Third Item',
+	},
+	{
+		id: '4e8372e6-5c86-4b0c-9f17-1a1d56b9a0e1',
+		title: 'Fourth Item',
+	},
+	{
+		id: '8f4c57e8-2763-498d-9c99-720a1f4eae03',
+		title: 'Fifth Item',
+	},
+	{
+		id: 'f6fe346e-80b8-4f91-8f27-2a3d49d18e9b',
+		title: 'Sixth Item',
+	},
+	{
+		id: '9c2ec5bb-89b1-4a7d-9759-2f7d3187b3a2',
+		title: 'Seventh Item',
+	},
+	{
+		id: '2d8c54fb-1a7b-4e5a-946d-789864cf05c3',
+		title: 'Eighth Item',
+	},
+	{
+		id: '7e1e9e6d-586b-4b2e-90a2-21f20c1b6b9e',
+		title: 'Ninth Item',
+	},
+	{
+		id: 'b4962f5f-e7e1-4d0f-923a-7941e86c7c90',
+		title: 'Tenth Item',
+	},
+];
+
+const styles = StyleSheet.create({
+	container: {
+		height: 400,
+		borderRadius: 6,
+		overflow: 'scroll',
+	},
+	wrapperChildren: {
+		padding: 20,
+		backgroundColor: white.main,
+		marginBottom: 2,
+	},
+});
+
+const renderComponent = ({item}) => (
+	<View key={item.id} style={styles.wrapperChildren}>
+		<Text>{item.title}</Text>
+	</View>
+);
+
+export const DefaultProps = (props) => (
+	<List {...props} style={styles.container} keyExtractor={(item) => item.id} />
+);
+
+DefaultProps.storyName = 'Default List';
+
+DefaultProps.args = {
+	data: fakeData,
+	type: 'flatList',
+	renderComponent,
+};


### PR DESCRIPTION
### LINK DE TICKET:

https://janiscommerce.atlassian.net/browse/JUIP-131

### DESCRIPCIÓN DEL REQUERIMIENTO:

La idea de este componente es que el mismo pueda renderizar el array que se le pase y, a partir de una prop, determinar si se estará renderizando en una FlatList o en un ScrollView, esto para poder dar más versatilidad al componente y poder emplearlo en más lugares

### DESCRIPCIÓN DE LA SOLUCIÓN:

- Se unificaron **FlatList** y **Scrollview** en un solo componente y hereda todas las props de los componentes de lista. 

Prop | Default | Requerido | Tipo | Obs.
-- | -- | -- | -- | --
data | null | true | array: string, mumber, object | puede ser un array de objetos, string o number.
type | null | false | enum: flatList, scrollView | hereda las props de los componentes de lista.
renderComponent | null | true | React.ReactElement | recibe por parametros la info de data que es utilizado para pasarle el componente de forma custom.

### CÓMO SE PUEDE PROBAR?

1. Entramos a la rama **JUIP-132-agregar-componente-lista-a-ui-native** en **@janis-commerce/ui-native**
2. En consola tiramos `yalc push && yalc publish`
3. En el repo deen cualquier rama que usemos para probar tiramos `yalc add @janiscommerce/oauth-native && npm i`
4. Reemplazar cualquier componente de lista y realizar pruebas de estilos o pasarle props de de **Scrollview** o **FlatList** según lo que seleccione...


### SCREENSHOTS:



### DATOS EXTRA A TENER EN CUENTA:

Si bien pudieron heredarse todas las props de los componentes, como no hay formas de separarlas según lo que uno renderice _**tuvieron que ser fusionadas**_

