### PR TITLE
JUIP-137 corregir componentes cortados en storybook

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -14,7 +14,7 @@ global.STORIES = [
 		directory: './storybook/stories',
 		files: '**/*.stories.?(ts|tsx|js|jsx)',
 		importPathMatcher:
-			'^\\.[\\\\/](?:storybook[\\\\/]stories(?:[\\\\/](?!\\.)(?:(?:(?!(?:^|[\\\\/])\\.).)*?)[\\\\/]|[\\\\/]|$)(?!\\.)(?=.)[^\\\\/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$',
+			'^\\.[\\\\/](?:storybook\\/stories(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$',
 	},
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@janiscommerce/ui-native",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@janiscommerce/ui-native",
-			"version": "1.1.1",
+			"version": "1.2.0",
 			"license": "ISC",
 			"dependencies": {
 				"@gorhom/bottom-sheet": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@janiscommerce/ui-native",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "components library for Janis app",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/src/components/LoadingFullScreen/__snapshots__/index.test.tsx.snap
+++ b/src/components/LoadingFullScreen/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`LoadingFullScreen component render correct render only the loading 1`] 
       Array [
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgba(255, 255, 255, 0.75)",
+          "backgroundColor": "#ffffffbf",
           "flex": 1,
           "justifyContent": "center",
         },
@@ -191,7 +191,7 @@ exports[`LoadingFullScreen component render correct renders well the loading nex
       Array [
         Object {
           "alignItems": "center",
-          "backgroundColor": "rgba(255, 255, 255, 0.75)",
+          "backgroundColor": "#ffffffbf",
           "flex": 1,
           "justifyContent": "center",
         },

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -19,13 +19,13 @@ const primary: Primary = {
 const black: Black = {
 	main: '#2F2F2F',
 	dark: '#050505',
-	semiTransparent: 'rgba(0, 0, 0, 0.1)',
+	semiTransparent: '#0000001a',
 };
 const white: White = {
 	main: '#E8EAF6',
 	dark: '#D0D3E3',
 	light: '#F4F5FB',
-	semiTransparent: 'rgba(255, 255, 255, 0.75)',
+	semiTransparent: '#ffffffbf',
 };
 const grey: GreyScale = {
 	100: '#DDDFE2',

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -19,6 +19,7 @@ const primary: Primary = {
 const black: Black = {
 	main: '#2F2F2F',
 	dark: '#050505',
+	semiTransparent: 'rgba(0, 0, 0, 0.1)',
 };
 const white: White = {
 	main: '#E8EAF6',

--- a/src/ts/interfaces/colors.ts
+++ b/src/ts/interfaces/colors.ts
@@ -19,7 +19,7 @@ export interface gamaColor {
 	main: string;
 	dark: string;
 }
-export interface Black extends gamaColor {}
+
 export interface Success extends gamaColor {}
 export interface Error extends gamaColor {}
 export interface Warning extends gamaColor {}
@@ -28,5 +28,8 @@ export interface Primary extends gamaColor {
 	light: string;
 }
 export interface White extends Primary {
+	semiTransparent: string;
+}
+export interface Black extends gamaColor {
 	semiTransparent: string;
 }

--- a/storybook/decorators/CenterScrollView/index.js
+++ b/storybook/decorators/CenterScrollView/index.js
@@ -14,6 +14,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		display: 'flex',
 		flexWrap: 'wrap',
+		flexDirection: 'row',
 	},
 });
 

--- a/storybook/decorators/CenterScrollView/index.js
+++ b/storybook/decorators/CenterScrollView/index.js
@@ -14,9 +14,6 @@ const styles = StyleSheet.create({
 		flex: 1,
 		display: 'flex',
 		flexWrap: 'wrap',
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
 	},
 });
 

--- a/storybook/decorators/CenterScrollView/index.js
+++ b/storybook/decorators/CenterScrollView/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import {ScrollView, StyleSheet, View} from 'react-native';
+
+const CenterScrollView = ({children}) => {
+	return (
+		<ScrollView>
+			<View style={styles.main}>{children}</View>
+		</ScrollView>
+	);
+};
+
+const styles = StyleSheet.create({
+	main: {
+		flex: 1,
+		display: 'flex',
+		flexWrap: 'wrap',
+		flexDirection: 'row',
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+});
+
+export default CenterScrollView;

--- a/storybook/decorators/CenterView/index.js
+++ b/storybook/decorators/CenterView/index.js
@@ -1,19 +1,11 @@
 import React from 'react';
-import {ScrollView, StyleSheet, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 
 const CenterView = ({children}) => {
-	return (
-		<ScrollView contentContainerStyle={styles.scrollView}>
-			<View style={styles.main}>{children}</View>
-		</ScrollView>
-	);
+	return <View style={styles.main}>{children}</View>;
 };
 
 const styles = StyleSheet.create({
-	scrollView: {
-		paddingVertical: 25,
-		paddingHorizontal: 10,
-	},
 	main: {
 		flex: 1,
 		display: 'flex',
@@ -21,6 +13,8 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'center',
 		alignItems: 'center',
+		paddingVertical: 25,
+		paddingHorizontal: 10,
 	},
 });
 

--- a/storybook/stories/DesignStystem/Colors.stories.js
+++ b/storybook/stories/DesignStystem/Colors.stories.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import {View, ScrollView, SafeAreaView} from 'react-native';
+import {View, SafeAreaView} from 'react-native';
 import Text from '../../../src/components/Text';
-import {palette} from '../../../src/theme/palette';
+import {black, palette} from '../../../src/theme/palette';
+import CenterScrollView from '../../decorators/CenterScrollView';
 
 export default {
 	title: 'Design system/Colors',
@@ -12,28 +13,30 @@ export default {
 			},
 		},
 	},
+	decorators: [
+		(Story) => (
+			<CenterScrollView>
+				<Story />
+			</CenterScrollView>
+		),
+	],
 };
 
 const styles = {
 	Base: {fontFamily: 'Roboto'},
-	Container: {
-		width: '100%',
-		paddingLeft: 10,
-		paddingRight: 10,
-	},
 	ColorWrapper: {
 		display: 'flex',
 		flexDirection: 'row',
+		flexWrap: 'wrap',
 		gap: 40,
 		marginBottom: 30,
-	},
-	ColorContainer: {
-		display: 'flex',
 	},
 	ColorSquare: (color) => ({
 		backgroundColor: color,
 		width: 100,
 		height: 100,
+		borderColor: black.semiTransparent,
+		borderWidth: 1,
 	}),
 	TitleWrapper: {
 		fontSize: 24,
@@ -70,19 +73,15 @@ const renderColor = (colorData) => {
 
 export const Colors = () => (
 	<SafeAreaView>
-		<View style={styles.Container}>
-			<ScrollView>
-				{colorsKeys.map((title) => {
-					return (
-						<View key={title}>
-							<Text style={[styles.TitleWrapper, styles.Base]}>{title}</Text>
-							<View style={styles.ColorWrapper}>
-								<>{renderColor(title)}</>
-							</View>
-						</View>
-					);
-				})}
-			</ScrollView>
-		</View>
+		{colorsKeys.map((title) => {
+			return (
+				<View key={title}>
+					<Text style={[styles.TitleWrapper, styles.Base]}>{title}</Text>
+					<View style={styles.ColorWrapper}>
+						<>{renderColor(title)}</>
+					</View>
+				</View>
+			);
+		})}
 	</SafeAreaView>
 );

--- a/storybook/stories/DesignStystem/Colors.stories.js
+++ b/storybook/stories/DesignStystem/Colors.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, useWindowDimensions} from 'react-native';
+import {View} from 'react-native';
 import Text from '../../../src/components/Text';
 import {black, palette} from '../../../src/theme/palette';
 import CenterScrollView from '../../decorators/CenterScrollView';

--- a/storybook/stories/DesignStystem/Colors.stories.js
+++ b/storybook/stories/DesignStystem/Colors.stories.js
@@ -28,8 +28,8 @@ const styles = {
 		display: 'flex',
 		flexDirection: 'row',
 		flexWrap: 'wrap',
-		gap: 40,
 		marginBottom: 30,
+		// flexShrink: 0,
 	},
 	ColorSquare: (color) => ({
 		backgroundColor: color,
@@ -37,11 +37,15 @@ const styles = {
 		height: 100,
 		borderColor: black.semiTransparent,
 		borderWidth: 1,
+		marginRight: 10,
 	}),
 	TitleWrapper: {
 		fontSize: 24,
 		textTransform: 'capitalize',
 		marginBottom: 30,
+	},
+	Title: {
+		marginVertical: 5,
 	},
 };
 
@@ -64,15 +68,15 @@ const renderColor = (colorData) => {
 
 	return arrayComponent.map(({title, value}) => (
 		<View key={`${title}-${value}`} style={styles.ColorContainer}>
-			<Text>{title}</Text>
+			<Text style={styles.Title}>{title}</Text>
 			<View style={styles.ColorSquare(value)} />
-			<Text>{value}</Text>
+			<Text style={styles.Title}>{value}</Text>
 		</View>
 	));
 };
 
 export const Colors = () => (
-	<SafeAreaView>
+	<>
 		{colorsKeys.map((title) => {
 			return (
 				<View key={title}>
@@ -83,5 +87,5 @@ export const Colors = () => (
 				</View>
 			);
 		})}
-	</SafeAreaView>
+	</>
 );

--- a/storybook/stories/DesignStystem/Colors.stories.js
+++ b/storybook/stories/DesignStystem/Colors.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, useWindowDimensions} from 'react-native';
 import Text from '../../../src/components/Text';
 import {black, palette} from '../../../src/theme/palette';
 import CenterScrollView from '../../decorators/CenterScrollView';
@@ -24,12 +24,14 @@ export default {
 
 const styles = {
 	Base: {fontFamily: 'Roboto'},
+	Container: {
+		width: '100%',
+	},
 	ColorWrapper: {
 		display: 'flex',
 		flexDirection: 'row',
 		flexWrap: 'wrap',
 		marginBottom: 30,
-		flexShrink: 0,
 	},
 	ColorSquare: (color) => ({
 		backgroundColor: color,
@@ -75,17 +77,19 @@ const renderColor = (colorData) => {
 	));
 };
 
-export const Colors = () => (
-	<>
-		{colorsKeys.map((title) => {
-			return (
-				<View key={title}>
-					<Text style={[styles.TitleWrapper, styles.Base]}>{title}</Text>
-					<View style={styles.ColorWrapper}>
-						<>{renderColor(title)}</>
+export const Colors = () => {
+	return (
+		<View style={styles.Container}>
+			{colorsKeys.map((title) => {
+				return (
+					<View key={title}>
+						<Text style={[styles.TitleWrapper, styles.Base]}>{title}</Text>
+						<View style={styles.ColorWrapper}>
+							<>{renderColor(title)}</>
+						</View>
 					</View>
-				</View>
-			);
-		})}
-	</>
-);
+				);
+			})}
+		</View>
+	);
+};

--- a/storybook/stories/DesignStystem/Colors.stories.js
+++ b/storybook/stories/DesignStystem/Colors.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {View, SafeAreaView} from 'react-native';
+import {View} from 'react-native';
 import Text from '../../../src/components/Text';
 import {black, palette} from '../../../src/theme/palette';
 import CenterScrollView from '../../decorators/CenterScrollView';
@@ -29,7 +29,7 @@ const styles = {
 		flexDirection: 'row',
 		flexWrap: 'wrap',
 		marginBottom: 30,
-		// flexShrink: 0,
+		flexShrink: 0,
 	},
 	ColorSquare: (color) => ({
 		backgroundColor: color,

--- a/storybook/stories/DesignStystem/Icons.stories.js
+++ b/storybook/stories/DesignStystem/Icons.stories.js
@@ -3,10 +3,18 @@ import {View, Text, StyleSheet, useWindowDimensions} from 'react-native';
 import Icon from '../../../src/components/Icon';
 import {primary} from '../../../src/theme/palette';
 import iconsSelection from '../../../src/components/Icon/assets/fonts/selection.json';
+import CenterScrollView from '../../decorators/CenterScrollView';
 
 export default {
 	title: 'Design system/Icons',
 	argTypes: {color: {control: {type: 'color'}}},
+	decorators: [
+		(Story) => (
+			<CenterScrollView>
+				<Story />
+			</CenterScrollView>
+		),
+	],
 };
 
 export const DefaultProps = ({color, size, ...props}) => {


### PR DESCRIPTION
### LINK DE TICKET:

https://janiscommerce.atlassian.net/browse/JUIP-134

### DESCRIPCIÓN DEL REQUERIMIENTO:

**Contexto:**
Hay ciertos componentes que se están viendo cortados en la app de Storybook de la siguiente manera;

**Necesidad:**
Se requiere solucionar estos errores de estilos para que los componentes no se estén cortando

### DESCRIPCIÓN DE LA SOLUCIÓN:

- Creación de decorator **CenterScrollView**
- Se agregó **CenterScrollView** a las historias que necesitaban un scroll.
- Se corrigieron estilos en **storybook/stories/DesignStystem/Colors.stories.js**
- Se corrigieron los colores que no eran exadecimales

### CÓMO SE PUEDE PROBAR?.

- `npm start` y `npm run storybook:android` par achequear en app.
- `npm run storybook-web `para chequear en la web

### SCREENSHOTS:

**Funcionamiento en App:**
![Peek 2024-01-11 13-30](https://github.com/janis-commerce/ui-native/assets/60529414/c34bc602-81d3-40b0-94e0-17b76dfa6329)

**Funcionamiento en Web:**
![Peek 2024-01-11 13-32](https://github.com/janis-commerce/ui-native/assets/60529414/25a4af4c-1a0e-4e39-bc46-8c058f07b232)


### DATOS EXTRA A TENER EN CUENTA: