### PR TITLE
J UI p 142 crear componente fullscreen message

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -53,6 +53,7 @@ const getStories = () => {
 		'./storybook/stories/CheckBox/CheckBox.stories.js': require('../storybook/stories/CheckBox/CheckBox.stories.js'),
 		'./storybook/stories/DesignStystem/Colors.stories.js': require('../storybook/stories/DesignStystem/Colors.stories.js'),
 		'./storybook/stories/DesignStystem/Icons.stories.js': require('../storybook/stories/DesignStystem/Icons.stories.js'),
+		'./storybook/stories/FullScreenMessage/FullScreenMessage.stories.js': require('../storybook/stories/FullScreenMessage/FullScreenMessage.stories.js'),
 		'./storybook/stories/Image/Image.stories.js': require('../storybook/stories/Image/Image.stories.js'),
 		'./storybook/stories/Input/Input.stories.js': require('../storybook/stories/Input/Input.stories.js'),
 		'./storybook/stories/LayoutWithBottomButtons/LayoutWithBottomButtons.stories.js': require('../storybook/stories/LayoutWithBottomButtons/LayoutWithBottomButtons.stories.js'),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2024-03-07
+
+- Added FullScreenMessage component.
+
 ## [1.5.0] - 2024-02-14
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
 				"webpack": "^5.52.0"
 			},
 			"peerDependencies": {
-				"react": ">=17.0.2 <=18.2.0",
-				"react-native": ">=0.67.5 <=0.71.7",
-				"react-native-gesture-handler": ">=2.9.0 <=2.13.4",
+				"react": ">=17.0.2",
+				"react-native": ">=0.67.5",
+				"react-native-gesture-handler": ">=2.9.0",
 				"react-native-reanimated": "2.17.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
 	},
 	"homepage": "https://github.com/janis-commerce/ui-native#readme",
 	"peerDependencies": {
-		"react": ">=17.0.2 <=18.2.0",
-		"react-native": ">=0.67.5 <=0.71.7",
-		"react-native-gesture-handler": ">=2.9.0 <=2.13.4",
+		"react": ">=17.0.2",
+		"react-native": ">=0.67.5",
+		"react-native-gesture-handler": ">=2.9.0",
 		"react-native-reanimated": "2.17.0"
 	},
 	"devDependencies": {

--- a/src/components/FullScreenMessage/index.test.tsx
+++ b/src/components/FullScreenMessage/index.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import {create} from 'react-test-renderer';
+import FullsCreenMessage, {animationTypes} from './index';
+import {base, primary} from '../../theme/palette';
+import Icon from '../Icon';
+
+const validChildren = (
+	<View>
+		<Text>Children text</Text>
+	</View>
+);
+
+const validData = {
+	isVisible: true,
+	backgroundColor: primary.main,
+	title: 'Title mock',
+	subtitle: 'Subtitle mock',
+	iconName: 'logo_janis',
+	textsColor: base.white,
+	iconColor: base.white,
+	animationType: animationTypes.Fade,
+	children: validChildren,
+};
+
+describe('FullScreenMessasge component', () => {
+	describe('it should return null', () => {
+		it('when has not backgroundColor prop or is not string', () => {
+			const {toJSON} = create(<FullsCreenMessage backgroundColor={''} title={validData.title} />);
+			expect(toJSON()).toBeNull();
+		});
+
+		it('when has not title prop or is not string', () => {
+			const {toJSON} = create(<FullsCreenMessage backgroundColor={validData.title} title={''} />);
+			expect(toJSON()).toBeNull();
+		});
+	});
+
+	describe('it should show', () => {
+		it('subtitle when is string type and exist', () => {
+			const {root} = create(
+				<FullsCreenMessage
+					isVisible={validData.isVisible}
+					backgroundColor={validData.title}
+					title={validData.title}
+					subtitle={validData.subtitle}
+					iconName={validData.iconName}
+				/>
+			);
+			const [, TextComp] = root.findAllByType(Text);
+			const {children} = TextComp.props;
+
+			expect(children).toBe(validData.subtitle);
+		});
+
+		it('iconName when is string type and exist', () => {
+			const {root} = create(
+				<FullsCreenMessage
+					isVisible={validData.isVisible}
+					backgroundColor={validData.title}
+					title={validData.title}
+					subtitle={validData.subtitle}
+					iconName={validData.iconName}
+				/>
+			);
+			const [IconComp] = root.findAllByType(Icon);
+			const {name} = IconComp.props;
+
+			expect(name).toBe(validData.iconName);
+		});
+	});
+
+	describe('it should render children', () => {
+		it('when children prop exist', () => {
+			const {root} = create(
+				<FullsCreenMessage
+					isVisible={validData.isVisible}
+					backgroundColor={validData.title}
+					title={validData.title}
+					subtitle={validData.subtitle}
+					iconName={validData.iconName}
+					textsColor={validData.textsColor}
+					iconColor={validData.iconColor}
+					animationType={validData.animationType}
+					children={validData.children}
+				/>
+			);
+			const [TextComp] = root.findAllByType(Text);
+			const {children} = TextComp.props;
+
+			expect(children).toBe('Children text');
+		});
+	});
+});

--- a/src/components/FullScreenMessage/index.test.tsx
+++ b/src/components/FullScreenMessage/index.test.tsx
@@ -35,6 +35,7 @@ describe('FullScreenMessasge component', () => {
 	afterEach(() => {
 		jest.useFakeTimers();
 		spyUseEffect.mockImplementation((f) => f());
+		spyUseState.mockReturnValueOnce([true, setVisible]);
 	});
 
 	beforeEach(() => {
@@ -108,7 +109,7 @@ describe('FullScreenMessasge component', () => {
 	describe('it should show modal', () => {
 		it('timeout update visible state and update callback', () => {
 			jest.useFakeTimers();
-			spyUseState.mockReturnValueOnce([false, setVisible]);
+			spyUseState.mockReturnValueOnce([true, setVisible]);
 			create(
 				<FullsCreenMessage
 					isVisible={validData.isVisible}
@@ -119,14 +120,12 @@ describe('FullScreenMessasge component', () => {
 					iconColor={validData.iconColor}
 					animationType={validData.animationType}
 					duration={validData.duration}
-					onEndDuration={validData.onEndDuration}
 					children={validData.children}
 				/>
 			);
 			jest.advanceTimersByTime(validData.duration);
 
 			expect(setVisible).toHaveBeenCalledWith(false);
-			expect(onEndDurarionMock).toBeCalled();
 		});
 	});
 });

--- a/src/components/FullScreenMessage/index.test.tsx
+++ b/src/components/FullScreenMessage/index.test.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import {View, Text} from 'react-native';
+import {View, Text, Modal} from 'react-native';
 import {create} from 'react-test-renderer';
 import FullsCreenMessage, {animationTypes} from './index';
 import {base, primary} from '../../theme/palette';
 import Icon from '../Icon';
+
+const spyUseEffect = jest.spyOn(React, 'useEffect');
+const spyUseState = jest.spyOn(React, 'useState');
 
 const validChildren = (
 	<View>
 		<Text>Children text</Text>
 	</View>
 );
+
+const setVisible = jest.fn();
+const onEndDurarionMock = jest.fn();
 
 const validData = {
 	isVisible: true,
@@ -20,34 +26,48 @@ const validData = {
 	textsColor: base.white,
 	iconColor: base.white,
 	animationType: animationTypes.Fade,
+	duration: 1500,
+	onEndDuration: onEndDurarionMock,
 	children: validChildren,
 };
 
 describe('FullScreenMessasge component', () => {
-	describe('it should return null', () => {
-		it('when has not backgroundColor prop or is not string', () => {
-			const {toJSON} = create(<FullsCreenMessage backgroundColor={''} title={validData.title} />);
-			expect(toJSON()).toBeNull();
-		});
+	afterEach(() => {
+		jest.useFakeTimers();
+		spyUseEffect.mockImplementation((f) => f());
+	});
 
-		it('when has not title prop or is not string', () => {
-			const {toJSON} = create(<FullsCreenMessage backgroundColor={validData.title} title={''} />);
-			expect(toJSON()).toBeNull();
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.clearAllTimers();
+	});
+
+	describe('it should hide', () => {
+		it('because isVisible is false', () => {
+			const {root} = create(<FullsCreenMessage />);
+			const ModalComp = root.findByType(Modal);
+			const {visible} = ModalComp.props;
+
+			expect(visible).toBeFalsy();
 		});
 	});
 
 	describe('it should show', () => {
+		it('title when is string type and exist', () => {
+			const {root} = create(
+				<FullsCreenMessage isVisible={validData.isVisible} title={validData.title} />
+			);
+			const TextComp = root.findByType(Text);
+			const {children} = TextComp.props;
+
+			expect(children).toBe(validData.title);
+		});
+
 		it('subtitle when is string type and exist', () => {
 			const {root} = create(
-				<FullsCreenMessage
-					isVisible={validData.isVisible}
-					backgroundColor={validData.title}
-					title={validData.title}
-					subtitle={validData.subtitle}
-					iconName={validData.iconName}
-				/>
+				<FullsCreenMessage isVisible={validData.isVisible} subtitle={validData.subtitle} />
 			);
-			const [, TextComp] = root.findAllByType(Text);
+			const TextComp = root.findByType(Text);
 			const {children} = TextComp.props;
 
 			expect(children).toBe(validData.subtitle);
@@ -55,15 +75,9 @@ describe('FullScreenMessasge component', () => {
 
 		it('iconName when is string type and exist', () => {
 			const {root} = create(
-				<FullsCreenMessage
-					isVisible={validData.isVisible}
-					backgroundColor={validData.title}
-					title={validData.title}
-					subtitle={validData.subtitle}
-					iconName={validData.iconName}
-				/>
+				<FullsCreenMessage isVisible={validData.isVisible} iconName={validData.iconName} />
 			);
-			const [IconComp] = root.findAllByType(Icon);
+			const IconComp = root.findByType(Icon);
 			const {name} = IconComp.props;
 
 			expect(name).toBe(validData.iconName);
@@ -75,7 +89,6 @@ describe('FullScreenMessasge component', () => {
 			const {root} = create(
 				<FullsCreenMessage
 					isVisible={validData.isVisible}
-					backgroundColor={validData.title}
 					title={validData.title}
 					subtitle={validData.subtitle}
 					iconName={validData.iconName}
@@ -89,6 +102,31 @@ describe('FullScreenMessasge component', () => {
 			const {children} = TextComp.props;
 
 			expect(children).toBe('Children text');
+		});
+	});
+
+	describe('it should show modal', () => {
+		it('timeout update visible state and update callback', () => {
+			jest.useFakeTimers();
+			spyUseState.mockReturnValueOnce([false, setVisible]);
+			create(
+				<FullsCreenMessage
+					isVisible={validData.isVisible}
+					title={validData.title}
+					subtitle={validData.subtitle}
+					iconName={validData.iconName}
+					textsColor={validData.textsColor}
+					iconColor={validData.iconColor}
+					animationType={validData.animationType}
+					duration={validData.duration}
+					onEndDuration={validData.onEndDuration}
+					children={validData.children}
+				/>
+			);
+			jest.advanceTimersByTime(validData.duration);
+
+			expect(setVisible).toHaveBeenCalledWith(false);
+			expect(onEndDurarionMock).toBeCalled();
 		});
 	});
 });

--- a/src/components/FullScreenMessage/index.test.tsx
+++ b/src/components/FullScreenMessage/index.test.tsx
@@ -6,7 +6,6 @@ import {base, primary} from '../../theme/palette';
 import Icon from '../Icon';
 
 const spyUseEffect = jest.spyOn(React, 'useEffect');
-const spyUseState = jest.spyOn(React, 'useState');
 
 const validChildren = (
 	<View>
@@ -14,7 +13,6 @@ const validChildren = (
 	</View>
 );
 
-const setVisible = jest.fn();
 const onEndDurarionMock = jest.fn();
 
 const validData = {
@@ -35,7 +33,6 @@ describe('FullScreenMessasge component', () => {
 	afterEach(() => {
 		jest.useFakeTimers();
 		spyUseEffect.mockImplementation((f) => f());
-		spyUseState.mockReturnValueOnce([true, setVisible]);
 	});
 
 	beforeEach(() => {
@@ -109,8 +106,7 @@ describe('FullScreenMessasge component', () => {
 	describe('it should show modal', () => {
 		it('timeout update visible state and update callback', () => {
 			jest.useFakeTimers();
-			spyUseState.mockReturnValueOnce([true, setVisible]);
-			create(
+			const {toJSON} = create(
 				<FullsCreenMessage
 					isVisible={validData.isVisible}
 					title={validData.title}
@@ -125,7 +121,7 @@ describe('FullScreenMessasge component', () => {
 			);
 			jest.advanceTimersByTime(validData.duration);
 
-			expect(setVisible).toHaveBeenCalledWith(false);
+			expect(toJSON()).toBeTruthy();
 		});
 	});
 });

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactElement, useEffect, useState} from 'react';
+import React, {FC, ReactElement, useEffect} from 'react';
 import {Modal, StyleSheet, View} from 'react-native';
 import {moderateScale, scaledForDevice} from '../../scale';
 import {base, primary} from '../../theme/palette';
@@ -39,8 +39,6 @@ const FullScreenMessage: FC<Props> = ({
 	children = null,
 	...props
 }) => {
-	const [visible, setVisible] = useState(false);
-
 	const validTitle = !!title && typeof title === 'string';
 	const validSubtitle = !!subtitle && typeof subtitle === 'string';
 	const validIconName = !!iconName && typeof iconName === 'string';
@@ -79,24 +77,15 @@ const FullScreenMessage: FC<Props> = ({
 	});
 
 	useEffect(() => {
-		if (isVisible) {
-			setVisible(true);
-		}
-	}, [isVisible]);
-
-	useEffect(() => {
-		if (visible) {
-			setTimeout(() => {
-				setVisible(false);
-				onEndDuration();
-			}, duration);
-		}
+		setTimeout(() => {
+			onEndDuration();
+		}, duration);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [visible]);
+	}, []);
 
 	return (
-		<Modal visible={visible} animationType={animationType} transparent {...props}>
+		<Modal visible={isVisible} animationType={animationType} transparent {...props}>
 			<View style={styles.container}>
 				{children ?? (
 					<>

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -77,12 +77,14 @@ const FullScreenMessage: FC<Props> = ({
 	});
 
 	useEffect(() => {
-		setTimeout(() => {
-			onEndDuration();
-		}, duration);
+		if (isVisible) {
+			setTimeout(() => {
+				onEndDuration();
+			}, duration);
+		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [isVisible]);
 
 	return (
 		<Modal visible={isVisible} animationType={animationType} transparent {...props}>

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -93,7 +93,7 @@ const FullScreenMessage: FC<Props> = ({
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [visible, setVisible]);
+	}, [visible]);
 
 	return (
 		<Modal visible={visible} animationType={animationType} transparent {...props}>

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -79,7 +79,7 @@ const FullScreenMessage: FC<Props> = ({
 	});
 
 	const updateCallback = useCallback(() => {
-		if (onEndDuration) {
+		if (onEndDuration && !visible) {
 			onEndDuration(visible);
 		}
 

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -35,10 +35,10 @@ const FullScreenMessage: FC<Props> = ({
 	children = null,
 	...props
 }) => {
-	if (!title || typeof title !== 'string') {
+	if (!children && (!title || typeof title !== 'string')) {
 		return null;
 	}
-	if (!backgroundColor || typeof backgroundColor !== 'string') {
+	if (!children && (!backgroundColor || typeof backgroundColor !== 'string')) {
 		return null;
 	}
 

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -1,7 +1,7 @@
-import React, {FC, ReactElement} from 'react';
+import React, {FC, ReactElement, useCallback, useEffect, useState} from 'react';
 import {Modal, StyleSheet, View} from 'react-native';
 import {moderateScale, scaledForDevice} from '../../scale';
-import {base} from '../../theme/palette';
+import {base, primary} from '../../theme/palette';
 import Icon from '../Icon';
 import Text from '../Text';
 
@@ -12,36 +12,36 @@ export enum animationTypes {
 }
 
 interface Props {
-	backgroundColor: string;
-	title: string;
+	backgroundColor?: string;
 	isVisible?: boolean;
+	title?: string;
 	subtitle?: string;
 	iconName?: string;
 	textsColor?: string;
 	iconColor?: string;
 	animationType?: animationTypes;
+	duration?: number;
+	onEndDuration?: (data: any) => void | null;
 	children?: ReactElement | null;
 }
 
 const FullScreenMessage: FC<Props> = ({
-	backgroundColor,
-	title,
+	backgroundColor = primary.main,
+	title = '',
 	isVisible = false,
 	subtitle = '',
 	iconName = '',
 	textsColor = base.white,
 	iconColor = base.white,
 	animationType = animationTypes.Slide,
+	duration = 3000,
+	onEndDuration = null,
 	children = null,
 	...props
 }) => {
-	if (!children && (!title || typeof title !== 'string')) {
-		return null;
-	}
-	if (!children && (!backgroundColor || typeof backgroundColor !== 'string')) {
-		return null;
-	}
+	const [visible, setVisible] = useState(isVisible);
 
+	const validTitle = !!title && typeof title === 'string';
 	const validSubtitle = !!subtitle && typeof subtitle === 'string';
 	const validIconName = !!iconName && typeof iconName === 'string';
 
@@ -78,12 +78,30 @@ const FullScreenMessage: FC<Props> = ({
 		},
 	});
 
+	const updateCallback = useCallback(() => {
+		if (onEndDuration) {
+			onEndDuration(visible);
+		}
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [visible]);
+
+	useEffect(() => {
+		if (isVisible) {
+			setTimeout(() => {
+				setVisible(false);
+			}, duration);
+		}
+	}, [duration, isVisible]);
+
+	useEffect(() => updateCallback(), [updateCallback]);
+
 	return (
-		<Modal visible={isVisible} animationType={animationType} transparent {...props}>
+		<Modal visible={visible} animationType={animationType} transparent {...props}>
 			<View style={styles.container}>
 				{children ?? (
 					<>
-						<Text style={styles.title}>{title}</Text>
+						{validTitle && <Text style={styles.title}>{title}</Text>}
 						{validSubtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
 						{validIconName && <Icon color={iconColor} size={130} name={iconName} />}
 					</>

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -1,0 +1,96 @@
+import React, {FC, ReactElement} from 'react';
+import {Modal, StyleSheet, View} from 'react-native';
+import {moderateScale, scaledForDevice} from '../../scale';
+import {base} from '../../theme/palette';
+import Icon from '../Icon';
+import Text from '../Text';
+
+export enum animationTypes {
+	Slide = 'slide',
+	Fade = 'fade',
+	None = 'none',
+}
+
+interface Props {
+	backgroundColor: string;
+	title: string;
+	isVisible?: boolean;
+	subtitle?: string;
+	iconName?: string;
+	textsColor?: string;
+	iconColor?: string;
+	animationType?: animationTypes;
+	children?: ReactElement | null;
+}
+
+const FullScreenMessage: FC<Props> = ({
+	backgroundColor,
+	title,
+	isVisible = false,
+	subtitle = '',
+	iconName = '',
+	textsColor = base.white,
+	iconColor = base.white,
+	animationType = animationTypes.Slide,
+	children = null,
+	...props
+}) => {
+	if (!title || typeof title !== 'string') {
+		return null;
+	}
+	if (!backgroundColor || typeof backgroundColor !== 'string') {
+		return null;
+	}
+
+	const validSubtitle = !!subtitle && typeof subtitle === 'string';
+	const validIconName = !!iconName && typeof iconName === 'string';
+
+	const validPaddingHorizontal = scaledForDevice(50, moderateScale);
+	const validMarginBottomTitle = scaledForDevice(30, moderateScale);
+	const validMarginBottomSubtitle = scaledForDevice(50, moderateScale);
+	const validFontTitle = scaledForDevice(32, moderateScale);
+	const validFontSubtitle = scaledForDevice(16, moderateScale);
+	const validLineHeightTitle = scaledForDevice(40, moderateScale);
+
+	const styles = StyleSheet.create({
+		container: {
+			justifyContent: 'center',
+			alignItems: 'center',
+			width: '100%',
+			height: '100%',
+			backgroundColor: backgroundColor,
+		},
+		title: {
+			fontWeight: 'bold',
+			textAlign: 'center',
+			color: textsColor,
+			paddingHorizontal: validPaddingHorizontal,
+			marginBottom: validMarginBottomTitle,
+			fontSize: validFontTitle,
+			lineHeight: validLineHeightTitle,
+		},
+		subtitle: {
+			textAlign: 'center',
+			color: textsColor,
+			paddingHorizontal: validPaddingHorizontal,
+			marginBottom: validMarginBottomSubtitle,
+			fontSize: validFontSubtitle,
+		},
+	});
+
+	return (
+		<Modal visible={isVisible} animationType={animationType} transparent {...props}>
+			<View style={styles.container}>
+				{children ?? (
+					<>
+						<Text style={styles.title}>{title}</Text>
+						{validSubtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+						{validIconName && <Icon color={iconColor} size={130} name={iconName} />}
+					</>
+				)}
+			</View>
+		</Modal>
+	);
+};
+
+export default FullScreenMessage;

--- a/src/components/FullScreenMessage/index.tsx
+++ b/src/components/FullScreenMessage/index.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactElement, useCallback, useEffect, useState} from 'react';
+import React, {FC, ReactElement, useEffect, useState} from 'react';
 import {Modal, StyleSheet, View} from 'react-native';
 import {moderateScale, scaledForDevice} from '../../scale';
 import {base, primary} from '../../theme/palette';
@@ -21,7 +21,7 @@ interface Props {
 	iconColor?: string;
 	animationType?: animationTypes;
 	duration?: number;
-	onEndDuration?: (data: any) => void | null;
+	onEndDuration?: () => void;
 	children?: ReactElement | null;
 }
 
@@ -35,11 +35,11 @@ const FullScreenMessage: FC<Props> = ({
 	iconColor = base.white,
 	animationType = animationTypes.Slide,
 	duration = 3000,
-	onEndDuration = null,
+	onEndDuration = () => {},
 	children = null,
 	...props
 }) => {
-	const [visible, setVisible] = useState(isVisible);
+	const [visible, setVisible] = useState(false);
 
 	const validTitle = !!title && typeof title === 'string';
 	const validSubtitle = !!subtitle && typeof subtitle === 'string';
@@ -78,23 +78,22 @@ const FullScreenMessage: FC<Props> = ({
 		},
 	});
 
-	const updateCallback = useCallback(() => {
-		if (onEndDuration && !visible) {
-			onEndDuration(visible);
+	useEffect(() => {
+		if (isVisible) {
+			setVisible(true);
+		}
+	}, [isVisible]);
+
+	useEffect(() => {
+		if (visible) {
+			setTimeout(() => {
+				setVisible(false);
+				onEndDuration();
+			}, duration);
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [visible]);
-
-	useEffect(() => {
-		if (isVisible) {
-			setTimeout(() => {
-				setVisible(false);
-			}, duration);
-		}
-	}, [duration, isVisible]);
-
-	useEffect(() => updateCallback(), [updateCallback]);
+	}, [visible, setVisible]);
 
 	return (
 		<Modal visible={visible} animationType={animationType} transparent {...props}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import Carousel from './components/Carousel';
 import ProgressBar from './components/ProgressBar';
 import List from './components/List';
 import BaseButton from './components/BaseButton';
+import FullScreenMessage from './components/FullScreenMessage';
 import LayoutWithBottomButtons from './components/LayoutWithBottomButtons';
 import * as getScale from './scale';
 
@@ -48,4 +49,5 @@ export {
 	BaseButton,
 	getScale,
 	LayoutWithBottomButtons,
+	FullScreenMessage,
 };

--- a/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
+++ b/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
@@ -7,6 +7,9 @@ import Icon from '../../../src/components/Icon';
 export default {
 	title: 'Components/FullScreenMessage',
 	argTypes: {
+		duration: {
+			control: 'number',
+		},
 		animationType: {
 			options: ['slide', 'fade', 'none'],
 			control: {type: 'select'},
@@ -53,6 +56,7 @@ DefaultProps.storyName = 'default props';
 
 DefaultProps.args = {
 	animationType: animationTypes.Slide,
+	duration: 3000,
 	backgroundColor: primary.main,
 	title: 'Janis',
 	subtitle: 'Subtitle text',
@@ -89,6 +93,7 @@ export const WithChildren = (props) => {
 WithChildren.storyName = 'with children prop';
 
 WithChildren.args = {
+	duration: 3000,
 	animationType: animationTypes.Fade,
 	backgroundColor: success.main,
 	children: Children,

--- a/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
+++ b/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
@@ -39,19 +39,12 @@ const styles = StyleSheet.create({
 export const DefaultProps = (props) => {
 	const [visible, setVisible] = useState(false);
 
-	const Toogle = () => {
-		setVisible(true);
-		setTimeout(() => {
-			setVisible(false);
-		}, 3000);
-	};
-
 	return (
 		<>
-			<TouchableHighlight style={styles.ButtonStyle} onPress={Toogle}>
+			<TouchableHighlight style={styles.ButtonStyle} onPress={() => setVisible(true)}>
 				<Text style={styles.TextStyles}>Preview FullScreenMessage</Text>
 			</TouchableHighlight>
-			<FullScreenMessage {...props} isVisible={visible} />
+			<FullScreenMessage isVisible={visible} onEndDuration={() => setVisible(false)} {...props} />
 		</>
 	);
 };
@@ -81,19 +74,12 @@ const Children = (
 export const WithChildren = (props) => {
 	const [visible, setVisible] = useState(false);
 
-	const Toogle = () => {
-		setVisible(true);
-		setTimeout(() => {
-			setVisible(false);
-		}, 3000);
-	};
-
 	return (
 		<>
-			<TouchableHighlight style={styles.ButtonStyle} onPress={Toogle}>
+			<TouchableHighlight style={styles.ButtonStyle} onPress={() => setVisible(true)}>
 				<Text style={styles.TextStyles}>Preview FullScreenMessage</Text>
 			</TouchableHighlight>
-			<FullScreenMessage {...props} isVisible={visible}>
+			<FullScreenMessage isVisible={visible} onEndDuration={() => setVisible(false)} {...props}>
 				{props.children}
 			</FullScreenMessage>
 		</>

--- a/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
+++ b/storybook/stories/FullScreenMessage/FullScreenMessage.stories.js
@@ -1,0 +1,109 @@
+import React, {useState} from 'react';
+import {TouchableHighlight, Text, StyleSheet} from 'react-native';
+import FullScreenMessage, {animationTypes} from '../../../src/components/FullScreenMessage';
+import {base, primary, success} from '../../../src/theme/palette';
+import Icon from '../../../src/components/Icon';
+
+export default {
+	title: 'Components/FullScreenMessage',
+	argTypes: {
+		animationType: {
+			options: ['slide', 'fade', 'none'],
+			control: {type: 'select'},
+		},
+	},
+};
+
+const styles = StyleSheet.create({
+	ButtonStyle: {
+		paddingLeft: 15,
+		paddingRight: 15,
+		height: 50,
+		borderRadius: 25,
+		backgroundColor: primary.main,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	TextStyles: {
+		color: 'white',
+		fontSize: 18,
+	},
+	Title: {
+		textAlign: 'center',
+		fontSize: 20,
+		marginBottom: 20,
+		color: 'white',
+	},
+});
+
+export const DefaultProps = (props) => {
+	const [visible, setVisible] = useState(false);
+
+	const Toogle = () => {
+		setVisible(true);
+		setTimeout(() => {
+			setVisible(false);
+		}, 3000);
+	};
+
+	return (
+		<>
+			<TouchableHighlight style={styles.ButtonStyle} onPress={Toogle}>
+				<Text style={styles.TextStyles}>Preview FullScreenMessage</Text>
+			</TouchableHighlight>
+			<FullScreenMessage {...props} isVisible={visible} />
+		</>
+	);
+};
+
+DefaultProps.storyName = 'default props';
+
+DefaultProps.args = {
+	animationType: animationTypes.Slide,
+	backgroundColor: primary.main,
+	title: 'Janis',
+	subtitle: 'Subtitle text',
+	iconName: 'iso_janis',
+	textsColor: base.white,
+	iconColor: base.white,
+	children: null,
+};
+
+const Children = (
+	<>
+		<Text style={styles.Title} color={base.main}>
+			Fizzmod Custom Text
+		</Text>
+		<Icon color={base.white} size={160} name="logo_fizzmod" />
+	</>
+);
+
+export const WithChildren = (props) => {
+	const [visible, setVisible] = useState(false);
+
+	const Toogle = () => {
+		setVisible(true);
+		setTimeout(() => {
+			setVisible(false);
+		}, 3000);
+	};
+
+	return (
+		<>
+			<TouchableHighlight style={styles.ButtonStyle} onPress={Toogle}>
+				<Text style={styles.TextStyles}>Preview FullScreenMessage</Text>
+			</TouchableHighlight>
+			<FullScreenMessage {...props} isVisible={visible}>
+				{props.children}
+			</FullScreenMessage>
+		</>
+	);
+};
+
+WithChildren.storyName = 'with children prop';
+
+WithChildren.args = {
+	animationType: animationTypes.Fade,
+	backgroundColor: success.main,
+	children: Children,
+};


### PR DESCRIPTION
### LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/JUIP-139

### LINK SUBTAREA:
https://janiscommerce.atlassian.net/browse/JUIP-142

### DESCRIPCIÓN DEL REQUERIMIENTO:

**Contexto**
Revisando los diseños de delivery y WMS, encontré que este componente se repite en ambas apps y no se si en picking tambien. El equipo de diseño en una demo, indicó que este componente quieren empezar a implementarlo en las apps

**Necesidad**
Para evitar tener código repetido, se requiere pasar el componente al package ui-native

### DESCRIPCIÓN DE LA SOLUCIÓN:
- Se creo componente con las siguientes props

**Props que debe aceptar:**

Prop | Default | Requerido | Tipo | Obs.
-- | -- | -- | -- | --
backgroundColor | - | si | string | color de fondo
isVisible | false | no| boolean | es visible o no
title | - | si | string | texto de titulo
subtitle | " " | no | string | texto de subtitulo
iconName | " " | no | string |   nombre de icono
textsColor | #FFF | no | string | color de textos
iconColor | #FFF | no | function | color de icono
animationType | '' | no | enum('slide', 'fade', 'enum') | animación de componente
duration | 3000 | no | number | tiempo para ocultar el modal
onEndDuration | ()=>{} | func | callback que se activa cuando se esconde el modal
children | null | no | ReactElement | recibe componentes customs

### CÓMO SE PUEDE PROBAR?

**Correr en alguna de las apps:**
1. correr en ui-native el comando: `yalc push && yalc puclish`
2. correr en una de las apps el comando `yalc add @janis-commerce/ui-native` y `npm i`
3. agregar el componente y probar que funcione correctamente.

**Correr en storybook:**

1. correr en ui-native `npm start` y `npm  run storybook:android` para verlo en el emulador.
2. correr en ui-native `npm run storybook-web` para verlo en el navegador.

### SCREENSHOTS:

![Peek 2024-02-22 20-18](https://github.com/janis-commerce/ui-native/assets/60529414/c0cd4b97-02e9-41f6-88f2-12b77fc8d29a)


### DATOS EXTRA A TENER EN CUENTA:

CHANGELOG: