### PR TITLE
Fixed bug of Toast not closing when there is no close callback

### DIFF
--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -23,3 +23,9 @@ jest.mock('@gorhom/bottom-sheet', () => {
 		BottomSheetView: react.View,
 	};
 });
+
+jest.mock('react-native-toast-message', () => ({
+	show: jest.fn(),
+	hide: jest.fn(),
+	setRef: jest.fn(),
+}));

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -5,6 +5,7 @@ import {moderateScale, scaledForDevice} from '../../scale';
 import {defaultIcon} from './utils';
 import {base, black} from '../../theme/palette';
 import BaseToast, {BaseToastProps} from '../BaseToast';
+import ToastAction from 'react-native-toast-message';
 import Text from '../Text';
 import Icon from '../Icon';
 
@@ -44,6 +45,13 @@ const Toast: FC<ToastProps> = ({type, text1, text2, style, props}) => {
 	const defaultIconName = defaultIcon[type] || defaultIcon.notice;
 	const selectedIconName = customIcon || defaultIconName;
 	const horizontalAlign = validTitle ? 'flex-start' : 'center';
+
+	const handleActionCb = () => actionCb();
+
+	const handleCloseCb = () => {
+		ToastAction.hide();
+		onCloseCb();
+	};
 
 	const styles = StyleSheet.create({
 		container: {
@@ -109,12 +117,12 @@ const Toast: FC<ToastProps> = ({type, text1, text2, style, props}) => {
 
 			<View style={styles.feedbackWrapper}>
 				{actionTitle && (
-					<TouchableOpacity onPress={actionCb} activeOpacity={0.6}>
+					<TouchableOpacity onPress={handleActionCb} activeOpacity={0.6}>
 						<Text style={styles.actionTitle}>{actionTitle}</Text>
 					</TouchableOpacity>
 				)}
 				{showCloseIcon && (
-					<TouchableOpacity onPress={onCloseCb} activeOpacity={0.6}>
+					<TouchableOpacity onPress={handleCloseCb} activeOpacity={0.6}>
 						<Icon name="cross_light" color={validColor} size={24} style={styles.closeIcon} />
 					</TouchableOpacity>
 				)}


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-308

DESCRIPCIÓN DEL REQUERIMIENTO:
Contexto:

En las tres apps estamos usando notificaciones para mostrar distintos mensajes y tenemos bastante codigo duplicado como tambien distintas maneras de usarlo. Por ejemplo en picking tenemos varios tipos de toast que se podrían mejorar y simplificar.

Con todo el desarrollo de push notification, las notificaciones cada vez van a ser mas importantes y por tal motivo necesitamos tener dicha funcionalidad de una manera mas agnóstica, reutilizable y que permite escalar el codigo de una manera mas rápida para agilizar entregas

Necesidad:

Tener los distintos tipos de notificaciones desde la [libreria](https://github.com/janis-commerce/ui-native) con sus distintos tipos

Como funciona hoy en las apps?

Desde la [libreria](https://www.npmjs.com/package/react-native-toast-message) estamos usando en App.js el componente Toast, el cual se encarga de recibir la configuracion de todos los Toast posibles.

La configuracion implica declarar el tipo de toast (este tipo es importante porque luego se usa para mostrar los distintos Toast en base al tipo) y cada uno de ellos esta usando un componente BaseToast.

DESCRIPCIÓN DE LA SOLUCIÓN:

Se solucionó un bug que no estaba permitiendo cerrar el Toast desde el icono de cruz cuándo no se le pasaba un onCloseCb.

A su vez, se agregó un handleActionCb para que ambos callbacks del Toast queden claros e iguales.

CÓMO SE PUEDE PROBAR?

En el repo de ui-native correr en consola: yalc publish
En la app: yalc add @janis-commerce/ui-native && npm i
En App.js reemplazar el componente Toast que se usa como provider:
import {Toast as ToastProvider, configToast} from '@janiscommerce/ui-native';
		
//donde configAppToast es la configuracion de los toast locales
<ToastProvider
     config={{...configAppToast, ...configToast}}
     ref={(ref) => ToastProvider.setRef(ref)}
     position="bottom"
/>

Para probar que el bug se haya solucionado se lo puede hacer con el siguiente código, importando el Toast de UI-Native:

useEffect(() => {
		Toast.show({
			type: 'notice',
			text1: 'Notice!',
			text2: 'Lorem ipsum dolor sit amet, consectetur adipiscingsed ipsum dolorrrrdfds.',
			autoHide: false,
			showIcon: true,
			props: {
				showCloseIcon: true,
			},
		});
	}, []);

Tras salir el Toast se debe verificar que, al presionar la cruz para cerrarlo, el mismo se cierre correctamente aunque no se le pase la prop onCloseCb

SCREENSHOTS:
Demo: https://streamable.com/sgmeqj

CHANGELOG: