### PR TITLE
Fixed buttons positions for LayoutWithBottomButtons

### DIFF
--- a/src/components/molecules/Button/index.test.tsx
+++ b/src/components/molecules/Button/index.test.tsx
@@ -15,6 +15,14 @@ jest.spyOn(React, 'useEffect').mockImplementation((f) => f());
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 
 describe('Button component', () => {
+	describe('it does not render', () => {
+		it('as there is no value nor icon', () => {
+			const ButtonComponent = create(<Button />).toJSON();
+
+			expect(ButtonComponent).toBeFalsy();
+		});
+	});
+
 	describe('it renders correctly', () => {
 		it('when it has valie as minimum prop', () => {
 			const {root} = create(<Button value={validData.value} />);

--- a/src/components/molecules/Button/index.tsx
+++ b/src/components/molecules/Button/index.tsx
@@ -74,6 +74,10 @@ const Button: FC<ButtonProps> = ({
 	textStyle,
 	...props
 }) => {
+	if (!value && !icon) {
+		return null;
+	}
+
 	const validDisabled = disabled || isLoading;
 	const hasIconAndText = !!icon && !!value;
 	const borderRadius = variant === 'text' ? 6 : 50;

--- a/src/components/molecules/Button/index.tsx
+++ b/src/components/molecules/Button/index.tsx
@@ -66,7 +66,7 @@ const Button: FC<ButtonProps> = ({
 	color = 'primary',
 	iconPosition = 'left',
 	isLoading = false,
-	value = 'Button',
+	value = '',
 	icon = null,
 	disabled = false,
 	style,
@@ -89,12 +89,12 @@ const Button: FC<ButtonProps> = ({
 	});
 	const styles = StyleSheet.create(buttonStyles);
 
-	const LoadingCompontent = <Loading isLoading={isLoading} color={styles.loadingColor} size={24} />;
+	const LoadingComponent = <Loading isLoading={isLoading} color={styles.loadingColor} size={24} />;
 
 	const WrapperComponent = (
 		<View style={styles.direction}>
 			{icon && <Icon name={icon} style={[styles.icon, iconStyle]} size={24} />}
-			{value && <Text style={[styles.text, textStyle]}>{value}</Text>}
+			{!!value && <Text style={[styles.text, textStyle]}>{value}</Text>}
 		</View>
 	);
 
@@ -105,7 +105,7 @@ const Button: FC<ButtonProps> = ({
 			borderRadius={borderRadius}
 			disabled={validDisabled}
 			{...props}>
-			{isLoading ? LoadingCompontent : WrapperComponent}
+			{isLoading ? LoadingComponent : WrapperComponent}
 		</BaseButton>
 	);
 };

--- a/src/components/molecules/Button/utils/getButtonStyles/index.test.ts
+++ b/src/components/molecules/Button/utils/getButtonStyles/index.test.ts
@@ -44,14 +44,12 @@ describe('getMixedButtonStyles util', () => {
 				color: '#C4C6CC',
 				fontFamily: 'Roboto-Medium',
 				letterSpacing: 0,
-				lineHeight: 39.5,
 				fontSize: 29,
 			},
 			icon: {
 				fontWeight: '500',
 				fontFamily: 'Roboto-Medium',
 				letterSpacing: 0,
-				lineHeight: 39.5,
 				textAlign: 'center',
 				color: '#C4C6CC',
 			},
@@ -82,7 +80,6 @@ describe('getMixedButtonStyles util', () => {
 				color: '#fff',
 				fontFamily: 'Roboto-Medium',
 				letterSpacing: 0,
-				lineHeight: 39.5,
 				fontSize: 29,
 			},
 			icon: {
@@ -91,7 +88,6 @@ describe('getMixedButtonStyles util', () => {
 				color: '#fff',
 				fontFamily: 'Roboto-Medium',
 				letterSpacing: 0,
-				lineHeight: 39.5,
 			},
 			loadingColor: '#2979FF',
 		});

--- a/src/components/molecules/Button/utils/getButtonStyles/index.test.ts
+++ b/src/components/molecules/Button/utils/getButtonStyles/index.test.ts
@@ -42,9 +42,19 @@ describe('getMixedButtonStyles util', () => {
 				fontWeight: '500',
 				textAlign: 'center',
 				color: '#C4C6CC',
+				fontFamily: 'Roboto-Medium',
+				letterSpacing: 0,
+				lineHeight: 39.5,
 				fontSize: 29,
 			},
-			icon: {fontWeight: '500', textAlign: 'center', color: '#C4C6CC'},
+			icon: {
+				fontWeight: '500',
+				fontFamily: 'Roboto-Medium',
+				letterSpacing: 0,
+				lineHeight: 39.5,
+				textAlign: 'center',
+				color: '#C4C6CC',
+			},
 			loadingColor: '#2979FF',
 		});
 	});
@@ -70,9 +80,19 @@ describe('getMixedButtonStyles util', () => {
 				fontWeight: '500',
 				textAlign: 'center',
 				color: '#fff',
+				fontFamily: 'Roboto-Medium',
+				letterSpacing: 0,
+				lineHeight: 39.5,
 				fontSize: 29,
 			},
-			icon: {fontWeight: '500', textAlign: 'center', color: '#fff'},
+			icon: {
+				fontWeight: '500',
+				textAlign: 'center',
+				color: '#fff',
+				fontFamily: 'Roboto-Medium',
+				letterSpacing: 0,
+				lineHeight: 39.5,
+			},
 			loadingColor: '#2979FF',
 		});
 	});

--- a/src/components/molecules/Button/utils/getButtonStyles/utils/styleConfigs/index.ts
+++ b/src/components/molecules/Button/utils/getButtonStyles/utils/styleConfigs/index.ts
@@ -110,7 +110,6 @@ export const styleConfig = {
 		textAlign: 'center',
 		fontFamily: 'Roboto-Medium',
 		letterSpacing: 0,
-		lineHeight: scaledForDevice(19, moderateScale),
 	},
 	icon: {
 		margin: {

--- a/src/components/molecules/Button/utils/getButtonStyles/utils/styleConfigs/index.ts
+++ b/src/components/molecules/Button/utils/getButtonStyles/utils/styleConfigs/index.ts
@@ -108,6 +108,9 @@ export const styleConfig = {
 	text: {
 		fontWeight: '500',
 		textAlign: 'center',
+		fontFamily: 'Roboto-Medium',
+		letterSpacing: 0,
+		lineHeight: scaledForDevice(19, moderateScale),
 	},
 	icon: {
 		margin: {

--- a/src/components/molecules/LayoutWithBottomButtons/index.test.tsx
+++ b/src/components/molecules/LayoutWithBottomButtons/index.test.tsx
@@ -2,9 +2,10 @@ import {View, Text} from 'react-native';
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import {create} from 'react-test-renderer';
-import Button from 'atoms/BaseButton';
+import Button from 'molecules/Button';
 import LayoutWithBottomButtons from './index';
 import * as utils from './utils';
+import {keyColor} from 'molecules/Button';
 
 describe('LayoutWithBottomButtons Layout', () => {
 	const parseButtonsStyles = jest.spyOn(utils, 'parseButtonsStyles');
@@ -50,8 +51,8 @@ describe('LayoutWithBottomButtons Layout', () => {
 			const testText = 'Some Content';
 			const testButton = [
 				{
-					iconName: 'home',
-					color: 'success',
+					icon: 'home',
+					color: 'success' as keyColor,
 					onPressHandler: jest.fn(),
 				},
 			];
@@ -70,10 +71,10 @@ describe('LayoutWithBottomButtons Layout', () => {
 
 		it('render one button correctly', () => {
 			const testText = 'Some Content';
-			const testColor = 'success';
+			const testColor = 'success' as keyColor;
 			const testButton = [
 				{
-					iconName: 'home',
+					icon: 'home',
 					color: testColor,
 					onPressHandler: jest.fn(),
 				},
@@ -96,16 +97,16 @@ describe('LayoutWithBottomButtons Layout', () => {
 
 		it('render two buttons correctly', () => {
 			const testText = 'Some Content';
-			const testColor1 = 'success';
-			const testColor2 = 'warning';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
 			const testButtons = [
 				{
-					iconName: 'home',
+					icon: 'home',
 					color: testColor1,
 					onPressHandler: jest.fn(),
 				},
 				{
-					iconName: 'camera',
+					icon: 'camera',
 					color: testColor2,
 					onPressHandler: jest.fn(),
 				},
@@ -128,24 +129,167 @@ describe('LayoutWithBottomButtons Layout', () => {
 			expect(secondButtonColor).toBe(testColor2);
 		});
 
-		it('render three buttons correctly - variant rounded', () => {
+		it('render two buttons with only icons correctly - variant roundedOnTop', () => {
 			const testText = 'Some Content';
-			const testColor1 = 'success';
-			const testColor2 = 'warning';
-			const testColor3 = 'error';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
 			const testButtons = [
 				{
-					iconName: 'home',
+					icon: 'home',
+					color: testColor1,
+					onPressHandler: jest.fn(),
+					width: 20,
+				},
+				{
+					icon: 'camera',
+					color: testColor2,
+					onPressHandler: jest.fn(),
+				},
+			];
+
+			const LayoutInstance = create(
+				<LayoutWithBottomButtons variant="roundedOnTop" buttons={testButtons}>
+					<View>
+						<Text>{testText}</Text>
+					</View>
+				</LayoutWithBottomButtons>
+			).root;
+
+			const Buttons = LayoutInstance.findAllByType(Button);
+			const {color: firstButtonColor} = Buttons[0].props;
+			const {color: secondButtonColor} = Buttons[1].props;
+
+			expect(Buttons.length).toBe(2);
+			expect(firstButtonColor).toBe(testColor1);
+			expect(secondButtonColor).toBe(testColor2);
+		});
+
+		it('render two buttons correctly - variant roundedOnTop', () => {
+			const testText = 'Some Content';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
+			const testButtons = [
+				{
+					icon: 'home',
+					value: 'Button',
+					color: testColor1,
+					onPressHandler: jest.fn(),
+					width: 20,
+				},
+				{
+					icon: 'camera',
+					value: 'Button',
+					color: testColor2,
+					onPressHandler: jest.fn(),
+				},
+			];
+
+			const LayoutInstance = create(
+				<LayoutWithBottomButtons variant="roundedOnTop" buttons={testButtons}>
+					<View>
+						<Text>{testText}</Text>
+					</View>
+				</LayoutWithBottomButtons>
+			).root;
+
+			const Buttons = LayoutInstance.findAllByType(Button);
+			const {color: firstButtonColor} = Buttons[0].props;
+			const {color: secondButtonColor} = Buttons[1].props;
+
+			expect(Buttons.length).toBe(2);
+			expect(firstButtonColor).toBe(testColor1);
+			expect(secondButtonColor).toBe(testColor2);
+		});
+
+		it('render two icon buttons correctly - variant rounded', () => {
+			const testText = 'Some Content';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
+			const testButtons = [
+				{
+					icon: 'home',
 					color: testColor1,
 					onPressHandler: jest.fn(),
 				},
 				{
-					iconName: 'camera',
+					icon: 'camera',
 					color: testColor2,
 					onPressHandler: jest.fn(),
 				},
+			];
+
+			const LayoutInstance = create(
+				<LayoutWithBottomButtons buttons={testButtons} variant="rounded">
+					<View>
+						<Text>{testText}</Text>
+					</View>
+				</LayoutWithBottomButtons>
+			).root;
+
+			const Buttons = LayoutInstance.findAllByType(Button);
+			const {color: firstButtonColor} = Buttons[0].props;
+			const {color: secondButtonColor} = Buttons[1].props;
+
+			expect(Buttons.length).toBe(2);
+			expect(firstButtonColor).toBe(testColor1);
+			expect(secondButtonColor).toBe(testColor2);
+		});
+
+		it('render two buttons correctly - variant rounded', () => {
+			const testText = 'Some Content';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
+			const testButtons = [
 				{
-					iconName: 'box',
+					icon: 'home',
+					value: 'Button',
+					color: testColor1,
+					onPressHandler: jest.fn(),
+				},
+				{
+					icon: 'camera',
+					value: 'Button',
+					color: testColor2,
+					onPressHandler: jest.fn(),
+				},
+			];
+
+			const LayoutInstance = create(
+				<LayoutWithBottomButtons buttons={testButtons} variant="rounded">
+					<View>
+						<Text>{testText}</Text>
+					</View>
+				</LayoutWithBottomButtons>
+			).root;
+
+			const Buttons = LayoutInstance.findAllByType(Button);
+			const {color: firstButtonColor} = Buttons[0].props;
+			const {color: secondButtonColor} = Buttons[1].props;
+
+			expect(Buttons.length).toBe(2);
+			expect(firstButtonColor).toBe(testColor1);
+			expect(secondButtonColor).toBe(testColor2);
+		});
+
+		it('render three buttons correctly - variant rounded', () => {
+			const testText = 'Some Content';
+			const testColor1 = 'success' as keyColor;
+			const testColor2 = 'warning' as keyColor;
+			const testColor3 = 'error' as keyColor;
+			const testButtons = [
+				{
+					icon: 'home',
+					color: testColor1,
+					onPressHandler: jest.fn(),
+				},
+				{
+					icon: 'camera',
+					color: testColor2,
+					onPressHandler: jest.fn(),
+					width: 25,
+				},
+				{
+					icon: 'box',
 					color: testColor3,
 					onPressHandler: jest.fn(),
 				},

--- a/src/components/molecules/LayoutWithBottomButtons/index.tsx
+++ b/src/components/molecules/LayoutWithBottomButtons/index.tsx
@@ -1,10 +1,10 @@
 import React, {ReactElement} from 'react';
 import {StyleSheet, ViewProps, View} from 'react-native';
-import BaseButton from 'atoms/BaseButton';
 import {palette} from 'theme/palette';
 import {moderateScale, scaledForDevice} from 'scale';
 import {validVariants, parseButtonsStyles, buttonWrapperVariantStyles} from './utils';
 import type {IlayoutButtons} from './utils';
+import Button from 'molecules/Button';
 
 interface LayoutWithBottomButtonsProps extends ViewProps {
 	children: ReactElement | string;
@@ -35,6 +35,8 @@ const LayoutWithBottomButtons = ({
 		return null;
 	}
 
+	const isRoundedOnTopVariant = selectedVariant === validVariants.roundedOnTop;
+
 	const styles = StyleSheet.create({
 		Container: {
 			flex: 1,
@@ -54,7 +56,7 @@ const LayoutWithBottomButtons = ({
 		},
 		ButtonsWrapper: {
 			...buttonWrapperVariantStyles(selectedVariant),
-			flexDirection: 'row',
+			flexDirection: isRoundedOnTopVariant ? 'column' : 'row',
 			justifyContent: 'space-between',
 			backgroundColor: validBtnBgColor,
 			marginTop: 'auto',
@@ -72,10 +74,10 @@ const LayoutWithBottomButtons = ({
 			<View style={[styles.Container]} {...props}>
 				{children}
 				<View style={[styles.FullButtonsRoundedWrapper]}>
-					<BaseButton {...fullWidthButton} />
+					<Button {...fullWidthButton} />
 					<View style={[styles.TwoButtonsWrapper]}>
 						{newBtns.map(({...buttonData}, index) => (
-							<BaseButton key={index.toString()} {...buttonData} />
+							<Button key={index.toString()} {...buttonData} />
 						))}
 					</View>
 				</View>
@@ -92,7 +94,7 @@ const LayoutWithBottomButtons = ({
 			{children}
 			<View style={[styles.ButtonsWrapper]}>
 				{parsedButtons.map(({...buttonData}, index) => (
-					<BaseButton key={index.toString()} {...buttonData} />
+					<Button key={index.toString()} {...buttonData} />
 				))}
 			</View>
 		</View>

--- a/src/components/molecules/LayoutWithBottomButtons/utils/index.test.ts
+++ b/src/components/molecules/LayoutWithBottomButtons/utils/index.test.ts
@@ -1,20 +1,21 @@
+import {keyColor} from 'molecules/Button';
 import {buttonWrapperVariantStyles, parseButtonsStyles} from './index';
 import {moderateScale, scaledForDevice} from 'scale';
 
 const layoutButtons = [
 	{
 		icon: 'keyboard',
-		pressedColor: '#FFFFFF',
+		pressedColor: '#FFFFFF' as keyColor,
 		onPress: jest.fn(),
 	},
 	{
 		icon: 'camera',
-		color: '#fgfgfg',
+		color: '#fgfgfg' as keyColor,
 		onPress: jest.fn(),
 	},
 	{
 		icon: 'check_light',
-		color: 'success',
+		color: 'success' as keyColor,
 		disabled: true,
 		onPress: jest.fn(),
 	},
@@ -75,29 +76,29 @@ describe('LayoutWithBottomButtons utils', () => {
 			it('2 buttons - should adjust the size correctly', () => {
 				const buttons = layoutButtons.slice(0, 2);
 				const response = parseButtonsStyles(buttons, 'rounded');
-				expect(response[0].style?.width).toEqual('49%');
-				expect(response[1].style?.width).toEqual('49%');
+				expect(response[0].style?.width).toEqual('auto');
+				expect(response[1].style?.width).toEqual('75%');
 			});
 
 			it('2 buttons - should respect the defined sizes', () => {
 				const buttons = layoutButtons.map((btn) => ({...btn, width: 30})).slice(0, 2);
 				const response = parseButtonsStyles(buttons, 'rounded');
-				expect(response[0].style?.width).toEqual(30);
-				expect(response[1].style?.width).toEqual(30);
+				expect(response[0].style?.width).toEqual('auto');
+				expect(response[1].style?.width).toEqual('75%');
 			});
 
 			it('2 buttons - the first button is full width', () => {
 				const buttons = layoutButtons.map((btn) => ({...btn, width: '100%'})).slice(0, 2);
 				const response = parseButtonsStyles(buttons, 'rounded');
-				expect(response[0].style?.width).toEqual('100%');
-				expect(response[1].style?.width).toEqual('100%');
+				expect(response[0].style?.width).toEqual('auto');
+				expect(response[1].style?.width).toEqual('75%');
 			});
 
 			it('2 buttons - if an invalid width is passed, the default is applied', () => {
 				const buttons = layoutButtons.map((btn) => ({...btn, width: '30'})).slice(0, 2);
 				const response = parseButtonsStyles(buttons, 'rounded');
-				expect(response[0].style?.width).toEqual('49%');
-				expect(response[1].style?.width).toEqual('49%');
+				expect(response[0].style?.width).toEqual('auto');
+				expect(response[1].style?.width).toEqual('75%');
 			});
 
 			it('1 button - should adjust the size correctly', () => {

--- a/src/components/molecules/LayoutWithBottomButtons/utils/index.ts
+++ b/src/components/molecules/LayoutWithBottomButtons/utils/index.ts
@@ -1,14 +1,15 @@
+import {keyColor} from 'molecules/Button';
 import {PressableProps, ViewStyle, TextStyle} from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
 import {palette} from 'theme/palette';
 
 export interface IlayoutButtons extends PressableProps {
-	title?: string | null;
+	value?: string | null;
 	icon?: string;
 	iconRight?: boolean;
 	disabled?: boolean;
 	borderRadius?: number;
-	color?: string;
+	color?: keyColor;
 	pressedColor?: string;
 	style?: ViewStyle;
 	iconStyle?: ViewStyle;
@@ -21,17 +22,19 @@ interface IvalidVariants {
 	[key: string]: string;
 	squared: string;
 	rounded: string;
+	roundedOnTop: string;
 	default: string;
 }
 
 export const validVariants: IvalidVariants = {
 	squared: 'squared',
 	rounded: 'rounded',
+	roundedOnTop: 'roundedOnTop',
 	default: 'squared',
 };
 
 const buttonVariantStyles = (variant: string | null) => ({
-	...(variant === 'rounded' && {
+	...((variant === 'rounded' || variant === 'roundedOnTop') && {
 		borderRadius: scaledForDevice(48, moderateScale),
 		height: scaledForDevice(48, moderateScale),
 	}),
@@ -59,6 +62,9 @@ export const buttonWrapperVariantStyles = (variant: string) => ({
 	...(variant === 'rounded' && {
 		padding: scaledForDevice(16, moderateScale),
 	}),
+	...(variant === 'roundedOnTop' && {
+		padding: scaledForDevice(16, moderateScale),
+	}),
 });
 
 const validWidth = (width: string | number | undefined) => {
@@ -80,7 +86,8 @@ export const parseButtonsStyles = (buttons: Array<IlayoutButtons>, variant: stri
 
 	const newButtons = [...buttons].slice(0, 3);
 
-	const areButtonsRounded = currentVariant === validVariants.rounded;
+	const areButtonsRounded =
+		currentVariant === validVariants.rounded || currentVariant === validVariants.roundedOnTop;
 
 	if (newButtons.length === 3 && areButtonsRounded) {
 		const parsedButtons = newButtons.map((btn, idx) => {
@@ -114,17 +121,27 @@ export const parseButtonsStyles = (buttons: Array<IlayoutButtons>, variant: stri
 	}
 
 	if (newButtons.length === 2 && areButtonsRounded) {
+		let isThereAnOnlyIconBtn = false;
 		const parsedButtons = newButtons.map((btn, idx) => {
 			const {backgroundColor, pressedColor} = getBackgroundColor(btn);
-			if (idx === 0 && btn.width === '100%') {
+			if (!isThereAnOnlyIconBtn) {
+				isThereAnOnlyIconBtn = !!btn.icon && !btn.value;
+			}
+
+			if (idx === 0) {
 				return {
 					...btn,
 					pressedColor,
 					style: {
 						...btn?.style,
 						backgroundColor,
-						width: btn.width,
-						marginBottom: scaledForDevice(10, moderateScale),
+						width: isThereAnOnlyIconBtn
+							? 'auto'
+							: currentVariant === 'roundedOnTop'
+							? '100%'
+							: '58%',
+						paddingHorizontal: scaledForDevice(24, moderateScale),
+						marginBottom: scaledForDevice(currentVariant === 'roundedOnTop' ? 8 : 0, moderateScale),
 						...buttonVariantStyles(currentVariant),
 					},
 				};
@@ -135,7 +152,7 @@ export const parseButtonsStyles = (buttons: Array<IlayoutButtons>, variant: stri
 				style: {
 					...btn?.style,
 					backgroundColor,
-					width: validWidth(btn.width) ?? '49%',
+					width: currentVariant === 'roundedOnTop' ? '100%' : isThereAnOnlyIconBtn ? '75%' : '40%',
 					...buttonVariantStyles(currentVariant),
 				},
 			};

--- a/storybook/stories/LayoutWithBottomButtons/LayoutWithBottomButtons.stories.js
+++ b/storybook/stories/LayoutWithBottomButtons/LayoutWithBottomButtons.stories.js
@@ -8,7 +8,7 @@ export default {
 	title: 'Components/LayoutWithBottomButtons',
 	argTypes: {
 		variant: {
-			options: ['squared', 'rounded'],
+			options: ['squared', 'rounded', 'roundedOnTop'],
 			control: {type: 'select'},
 		},
 		buttonBackgroundColor: {


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/JUIP-155

DESCRIPCIÓN DEL REQUERIMIENTO:
A partir del uso de los componentes LayoutWithBottomButtons y Button se encontraron errores en estos componentes, por el lado de LayoutWithBottomButtons no se están renderizando los botones y Button cuenta con un tipografía erronea.

DESCRIPCIÓN DE LA SOLUCIÓN:
Se corrigieron los errores en ambos componentes, añadiendo además las nuevas disposiciones necesarias para el LayoutWithBottomButtons según diseño.

CÓMO SE PUEDE PROBAR?
Vinculando el package con algún repo de las apps: https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI

Y probando que todas las distintas disposiciones del componente LayoutWithBottomButtons se vean correctamente

Para poder probarlo de una manera más sencilla se pueden utilizar los siguientes códigos para pasarle a la prop buttons del componentes:

**Botón de icono y botón con texto redondeados**
`const buttons = [
  {
  icon: 'camera',
  color: 'black',
  onPress: () => {},
  },
  {
  color: getColor('primary', 'main'),
  value: 'Continuar',
  onPress: () => {},
  },
]
`

**Dos botones de texto redondeados (uno siempre es más largo que el otro)**
`const buttons = [
  {
  color: getColor('primary', 'main'),
  value: 'Continuar',
  onPress: () => {},
  },
  {
  color: 'getColor('base', 'white')',
value: 'Posponer',
variant: 'outlined',
	textStyle: {
			color: getColor('primary', 'main'),
		},
  onPress: () => {},
  },
]
`
**Un botón sobre otro (pasarle al componente LayoutWithBottomButtons la variant "roundedOnTop"**
`const buttons = [
  {
  color: getColor('primary', 'main'),
  value: 'Continuar',
  onPress: () => {},
  },
  {
  color: 'getColor('base', 'white')',
value: 'Añadir Persona',
variant: 'outlined',
	textStyle: {
			color: getColor('primary', 'main'),
		},
  onPress: () => {},
  },
]
`
![Screenshot_20240925_155119_ui-native](https://github.com/user-attachments/assets/955ea50c-8f53-4eec-8aa2-f51f45bad8dc)
![Screenshot_20240925_155304_ui-native](https://github.com/user-attachments/assets/c607703e-796d-4416-9a87-d94f7a7541ae)
![Screenshot_20240925_155345_ui-native](https://github.com/user-attachments/assets/d43e27cd-9ee0-4751-a3ff-69e34f66f3a8)


DATOS EXTRA A TENER EN CUENTA:
CHANGELOG: