### PR TITLE
Appsrn 340 implementación del componente typography

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,6 @@ module.exports = {
 		'react/jsx-props-no-spreading': 'off',
 		'no-param-reassign': 'off',
 		'no-shadow': 'off',
-		'no-console': 'error',
+		'no-console': 'off',
 	},
 };

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"@testing-library/react-hooks": "^8.0.1",
 		"@testing-library/react-native": "^7.2.0",
 		"@types/jest": "^25.2.3",
+		"@types/node": "^22.9.0",
 		"@types/react": "^17.0.2",
 		"@types/react-native": "^0.63.2",
 		"@types/react-native-vector-icons": "^6.4.14",

--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -29,3 +29,5 @@ jest.mock('react-native-toast-message', () => ({
 	hide: jest.fn(),
 	setRef: jest.fn(),
 }));
+
+jest.spyOn(console, 'warn').mockImplementation(() => {});

--- a/src/components/atoms/BaseToast/index.test.tsx
+++ b/src/components/atoms/BaseToast/index.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import BaseToast, {Types} from './';
 
 const validProps = {
-	children: <Text>BaseToast</Text>,
+	children: <Typography>BaseToast</Typography>,
 	style: {color: 'red'},
 	type: Types.Notice,
 };

--- a/src/components/atoms/BaseToast/index.test.tsx
+++ b/src/components/atoms/BaseToast/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import BaseToast, {Types} from './';
 
 const validProps = {

--- a/src/components/atoms/RadioButton/index.test.tsx
+++ b/src/components/atoms/RadioButton/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import RadioButton from './index';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {TouchableOpacity} from 'react-native';
 
 describe('radioButton component', () => {
@@ -17,7 +17,7 @@ describe('radioButton component', () => {
 	});
 
 	it('should render correctly when receives a valid child', () => {
-		const child = <Text>valid child</Text>;
+		const child = <Typography>valid child</Typography>;
 
 		const {toJSON} = create(<RadioButton>{child}</RadioButton>);
 		expect(toJSON()).toBeTruthy();

--- a/src/components/atoms/RadioButton/index.test.tsx
+++ b/src/components/atoms/RadioButton/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import RadioButton from './index';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {TouchableOpacity} from 'react-native';
 
 describe('radioButton component', () => {

--- a/src/components/atoms/RadioButton/index.tsx
+++ b/src/components/atoms/RadioButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View, TouchableOpacity, StyleSheet, ViewStyle} from 'react-native';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import CheckBox from 'atoms/CheckBox';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 

--- a/src/components/atoms/RadioButton/index.tsx
+++ b/src/components/atoms/RadioButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View, TouchableOpacity, StyleSheet, ViewStyle} from 'react-native';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import CheckBox from 'atoms/CheckBox';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 
@@ -88,7 +88,7 @@ const RadioButton = ({
 				onPress={onPress}
 			/>
 			<View style={checkLeft ? checkToLeft : checkToRight}>
-				{isStringChild ? <Text>{children}</Text> : children}
+				{isStringChild ? <Typography>{children}</Typography> : children}
 			</View>
 		</TouchableOpacity>
 	);

--- a/src/components/atoms/StatusChip/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/StatusChip/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,14 @@ exports[`StatusChip component render correct a valid component is passed 1`] = `
           "fontFamily": "Roboto",
           "fontSize": 27,
         },
-        undefined,
+        Array [
+          undefined,
+          Object {
+            "fontSize": 14,
+            "fontWeight": "400",
+            "lineHeight": 18,
+          },
+        ],
       ]
     }
   >
@@ -56,14 +63,21 @@ exports[`StatusChip component render correct if a background is passed 1`] = `
           "fontFamily": "Roboto",
           "fontSize": 27,
         },
-        Object {
-          "color": "#fff",
-          "fontFamily": "Roboto",
-          "fontSize": 27,
-          "fontWeight": "900",
-          "lineHeight": 37.5,
-          "textAlign": "center",
-        },
+        Array [
+          Object {
+            "color": "#fff",
+            "fontFamily": "Roboto",
+            "fontSize": 27,
+            "fontWeight": "900",
+            "lineHeight": 37.5,
+            "textAlign": "center",
+          },
+          Object {
+            "fontSize": 14,
+            "fontWeight": "400",
+            "lineHeight": 18,
+          },
+        ],
       ]
     }
   >
@@ -95,14 +109,21 @@ exports[`StatusChip component render correct text is passed 1`] = `
           "fontFamily": "Roboto",
           "fontSize": 27,
         },
-        Object {
-          "color": "#2979FF",
-          "fontFamily": "Roboto",
-          "fontSize": 27,
-          "fontWeight": "900",
-          "lineHeight": 37.5,
-          "textAlign": "center",
-        },
+        Array [
+          Object {
+            "color": "#2979FF",
+            "fontFamily": "Roboto",
+            "fontSize": 27,
+            "fontWeight": "900",
+            "lineHeight": 37.5,
+            "textAlign": "center",
+          },
+          Object {
+            "fontSize": 14,
+            "fontWeight": "400",
+            "lineHeight": 18,
+          },
+        ],
       ]
     }
   >

--- a/src/components/atoms/StatusChip/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/StatusChip/__snapshots__/index.test.tsx.snap
@@ -19,18 +19,12 @@ exports[`StatusChip component render correct a valid component is passed 1`] = `
   <Text
     style={
       Array [
+        undefined,
         Object {
-          "fontFamily": "Roboto",
-          "fontSize": 27,
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 18,
         },
-        Array [
-          undefined,
-          Object {
-            "fontSize": 14,
-            "fontWeight": "400",
-            "lineHeight": 18,
-          },
-        ],
       ]
     }
   >
@@ -60,24 +54,18 @@ exports[`StatusChip component render correct if a background is passed 1`] = `
     style={
       Array [
         Object {
+          "color": "#fff",
           "fontFamily": "Roboto",
           "fontSize": 27,
+          "fontWeight": "900",
+          "lineHeight": 37.5,
+          "textAlign": "center",
         },
-        Array [
-          Object {
-            "color": "#fff",
-            "fontFamily": "Roboto",
-            "fontSize": 27,
-            "fontWeight": "900",
-            "lineHeight": 37.5,
-            "textAlign": "center",
-          },
-          Object {
-            "fontSize": 14,
-            "fontWeight": "400",
-            "lineHeight": 18,
-          },
-        ],
+        Object {
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 18,
+        },
       ]
     }
   >
@@ -106,24 +94,18 @@ exports[`StatusChip component render correct text is passed 1`] = `
     style={
       Array [
         Object {
+          "color": "#2979FF",
           "fontFamily": "Roboto",
           "fontSize": 27,
+          "fontWeight": "900",
+          "lineHeight": 37.5,
+          "textAlign": "center",
         },
-        Array [
-          Object {
-            "color": "#2979FF",
-            "fontFamily": "Roboto",
-            "fontSize": 27,
-            "fontWeight": "900",
-            "lineHeight": 37.5,
-            "textAlign": "center",
-          },
-          Object {
-            "fontSize": 14,
-            "fontWeight": "400",
-            "lineHeight": 18,
-          },
-        ],
+        Object {
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 18,
+        },
       ]
     }
   >

--- a/src/components/atoms/StatusChip/index.test.tsx
+++ b/src/components/atoms/StatusChip/index.test.tsx
@@ -2,7 +2,7 @@ import 'react-native';
 import React from 'react';
 import {create} from 'react-test-renderer';
 import StatusChip from './index';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {primary} from 'theme/palette';
 
 describe('StatusChip component', () => {
@@ -27,7 +27,7 @@ describe('StatusChip component', () => {
 		it('a valid component is passed', () => {
 			const {toJSON} = create(
 				<StatusChip>
-					<Text>Custom component</Text>
+					<Typography>Custom component</Typography>
 				</StatusChip>
 			);
 			expect(toJSON()).toMatchSnapshot();

--- a/src/components/atoms/StatusChip/index.test.tsx
+++ b/src/components/atoms/StatusChip/index.test.tsx
@@ -2,7 +2,7 @@ import 'react-native';
 import React from 'react';
 import {create} from 'react-test-renderer';
 import StatusChip from './index';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {primary} from 'theme/palette';
 
 describe('StatusChip component', () => {

--- a/src/components/atoms/StatusChip/index.tsx
+++ b/src/components/atoms/StatusChip/index.tsx
@@ -1,7 +1,7 @@
 import React, {ReactElement, isValidElement} from 'react';
 import {StyleSheet, ViewProps, View} from 'react-native';
 import {base, grey, primary} from 'theme/palette';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 
 interface StatusChipProps extends ViewProps {

--- a/src/components/atoms/StatusChip/index.tsx
+++ b/src/components/atoms/StatusChip/index.tsx
@@ -1,7 +1,7 @@
 import React, {ReactElement, isValidElement} from 'react';
 import {StyleSheet, ViewProps, View} from 'react-native';
 import {base, grey, primary} from 'theme/palette';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 
 interface StatusChipProps extends ViewProps {
@@ -51,7 +51,11 @@ const StatusChip = ({children, ...props}: StatusChipProps) => {
 
 	return (
 		<View style={styles(props).ViewStyles} {...props}>
-			{isCustomComponent ? children : <Text style={styles(props).TextStyles}>{children}</Text>}
+			{isCustomComponent ? (
+				children
+			) : (
+				<Typography style={styles(props).TextStyles}>{children}</Typography>
+			)}
 		</View>
 	);
 };

--- a/src/components/atoms/Text/index.tsx
+++ b/src/components/atoms/Text/index.tsx
@@ -7,20 +7,13 @@ import {
 	TextStyle,
 } from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
-import getStyleByTypography from './utils/getStyleByTypography';
 
-export type TypographyType = 'display' | 'heading' | 'title' | 'label' | 'body' | 'overline';
-
-export type TypographySize = 'large' | 'medium' | 'small';
-
-interface TextProps extends TextComponentProps {
+export interface TextProps extends TextComponentProps {
 	children?: ReactElement | string;
 	style?: StyleProp<TextStyle>;
-	type?: TypographyType;
-	size?: TypographySize;
 }
 
-const Text = ({children, style, type, size, ...props}: TextProps) => {
+const Text = ({children, style, ...props}: TextProps) => {
 	if (!children) {
 		return null;
 	}
@@ -34,13 +27,8 @@ const Text = ({children, style, type, size, ...props}: TextProps) => {
 		},
 	});
 
-	const typographyStyles = getStyleByTypography(
-		type as TypographyType | 'string',
-		size as TypographySize | 'string'
-	);
-
 	return (
-		<TextComponent style={[styles.TextStyles, style, typographyStyles.typography]} {...props}>
+		<TextComponent style={[styles.TextStyles, style]} {...props}>
 			{children}
 		</TextComponent>
 	);

--- a/src/components/atoms/Text/index.tsx
+++ b/src/components/atoms/Text/index.tsx
@@ -7,13 +7,20 @@ import {
 	TextStyle,
 } from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
+import getStyleByTypography from './utils/getStyleByTypography';
+
+export type TypographyType = 'display' | 'heading' | 'title' | 'label' | 'body' | 'overline';
+
+export type TypographySize = 'large' | 'medium' | 'small';
 
 interface TextProps extends TextComponentProps {
 	children?: ReactElement | string;
 	style?: StyleProp<TextStyle>;
+	type?: TypographyType;
+	size?: TypographySize;
 }
 
-const Text = ({children, style, ...props}: TextProps) => {
+const Text = ({children, style, type, size, ...props}: TextProps) => {
 	if (!children) {
 		return null;
 	}
@@ -27,8 +34,13 @@ const Text = ({children, style, ...props}: TextProps) => {
 		},
 	});
 
+	const typographyStyles = getStyleByTypography(
+		type as TypographyType | 'string',
+		size as TypographySize | 'string'
+	);
+
 	return (
-		<TextComponent style={[styles.TextStyles, style]} {...props}>
+		<TextComponent style={[styles.TextStyles, style, typographyStyles.typography]} {...props}>
 			{children}
 		</TextComponent>
 	);

--- a/src/components/atoms/Text/index.tsx
+++ b/src/components/atoms/Text/index.tsx
@@ -7,6 +7,7 @@ import {
 	TextStyle,
 } from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
+import {isDevEnv} from 'utils/index';
 
 export interface TextProps extends TextComponentProps {
 	children?: ReactElement | string;
@@ -27,6 +28,10 @@ const Text = ({children, style, ...props}: TextProps) => {
 		},
 	});
 
+	// istanbul ignore next
+	if (isDevEnv()) {
+		console.warn('This component is going to be deprecated soon.');
+	}
 	return (
 		<TextComponent style={[styles.TextStyles, style]} {...props}>
 			{children}

--- a/src/components/atoms/Text/utils/getStyleByTypography/index.ts
+++ b/src/components/atoms/Text/utils/getStyleByTypography/index.ts
@@ -1,0 +1,70 @@
+import {StyleSheet, TextStyle} from 'react-native';
+import typography, {Typography, TypographyItem} from 'theme/typography';
+
+// Define valid types and sizes
+type TypographyType = keyof Typography;
+type TypographySize = 'large' | 'medium' | 'small';
+
+const validTypes: TypographyType[] = Object.keys(typography) as TypographyType[];
+const validSizes: TypographySize[] = ['large', 'medium', 'small'];
+
+const defaultStyles = StyleSheet.create<{typography: TextStyle}>({
+	typography: {
+		fontWeight: typography.body.medium.weight,
+		fontSize: typography.body.medium.size,
+		lineHeight: typography.body.medium.lineHeight,
+	},
+});
+
+const getStyleByTypography = (type: TypographyType | string, size: TypographySize | string) => {
+	if (
+		!validTypes.includes(type as TypographyType) ||
+		!validSizes.includes(size as TypographySize)
+	) {
+		return defaultStyles;
+	}
+
+	const typographyType = type as TypographyType;
+	const typographySize = size as TypographySize;
+
+	if (typographyType === 'display') {
+		return StyleSheet.create({
+			typography: {
+				fontWeight: typography.display.weight,
+				fontSize: typography.display.size,
+				lineHeight: typography.display.lineHeight,
+			},
+		});
+	}
+
+	if (typographyType === 'overline' && typographySize === 'medium') {
+		return StyleSheet.create({
+			typography: {
+				fontWeight: typography.overline.large.weight,
+				fontSize: typography.overline.large.size,
+				lineHeight: typography.overline.large.lineHeight,
+				letterSpacing: typography.overline.large.spacing,
+			},
+		});
+	}
+
+	const typographyObject = typography[typographyType];
+	if (typographySize in typographyObject) {
+		const typographyStyle = typographyObject[
+			typographySize as keyof typeof typographyObject
+		] as TypographyItem;
+
+		return StyleSheet.create({
+			typography: {
+				fontWeight: typographyStyle.weight,
+				fontSize: typographyStyle.size,
+				lineHeight: typographyStyle.lineHeight,
+				letterSpacing: typographyStyle.spacing,
+			},
+		});
+	}
+
+	return defaultStyles;
+};
+
+export default getStyleByTypography;

--- a/src/components/atoms/Typography/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Typography/__snapshots__/index.test.tsx.snap
@@ -4,18 +4,12 @@ exports[`Typography component render correct match snapshot with default typogra
 <Text
   style={
     Array [
+      undefined,
       Object {
-        "fontFamily": "Roboto",
-        "fontSize": 27,
+        "fontSize": 14,
+        "fontWeight": "400",
+        "lineHeight": 18,
       },
-      Array [
-        undefined,
-        Object {
-          "fontSize": 14,
-          "fontWeight": "400",
-          "lineHeight": 18,
-        },
-      ],
     ]
   }
 >

--- a/src/components/atoms/Typography/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Typography/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typography component render correct match snapshot with default typography 1`] = `
+<Text
+  style={
+    Array [
+      Object {
+        "fontFamily": "Roboto",
+        "fontSize": 27,
+      },
+      Array [
+        undefined,
+        Object {
+          "fontSize": 14,
+          "fontWeight": "400",
+          "lineHeight": 18,
+        },
+      ],
+    ]
+  }
+>
+  Janis Picking
+</Text>
+`;

--- a/src/components/atoms/Typography/index.test.tsx
+++ b/src/components/atoms/Typography/index.test.tsx
@@ -1,0 +1,21 @@
+import 'react-native';
+import React from 'react';
+import {create} from 'react-test-renderer';
+import Text from './index';
+import Typography from './index';
+
+describe('Typography component', () => {
+	describe('return error because children is undefined', () => {
+		it('undefined children', () => {
+			const {toJSON} = create(<Text />);
+			expect(toJSON()).toBeNull();
+		});
+	});
+
+	describe('render correct', () => {
+		it('match snapshot with default typography', () => {
+			const {toJSON} = create(<Typography>Janis Picking</Typography>);
+			expect(toJSON()).toMatchSnapshot();
+		});
+	});
+});

--- a/src/components/atoms/Typography/index.tsx
+++ b/src/components/atoms/Typography/index.tsx
@@ -1,0 +1,34 @@
+import React, {ReactElement} from 'react';
+import {StyleProp, TextStyle} from 'react-native';
+import getStyleByTypography from './utils/getStyleByTypography';
+import Text, {TextProps} from 'atoms/Text';
+
+export type TypographyType = 'display' | 'heading' | 'title' | 'label' | 'body' | 'overline';
+
+export type TypographySize = 'large' | 'medium' | 'small';
+
+interface TypographyProps extends TextProps {
+	children?: ReactElement | string;
+	style?: StyleProp<TextStyle>;
+	type?: TypographyType;
+	size?: TypographySize;
+}
+
+const Typography = ({children, style, type, size, ...props}: TypographyProps) => {
+	if (!children) {
+		return null;
+	}
+
+	const typographyStyles = getStyleByTypography(
+		type as TypographyType | 'string',
+		size as TypographySize | 'string'
+	);
+
+	return (
+		<Text style={[style, typographyStyles.typography]} {...props}>
+			{children}
+		</Text>
+	);
+};
+
+export default Typography;

--- a/src/components/atoms/Typography/index.tsx
+++ b/src/components/atoms/Typography/index.tsx
@@ -1,7 +1,6 @@
 import React, {ReactElement} from 'react';
-import {StyleProp, TextStyle} from 'react-native';
+import {Text, StyleProp, TextStyle, TextProps} from 'react-native';
 import getStyleByTypography from './utils/getStyleByTypography';
-import Text, {TextProps} from 'atoms/Text';
 
 export type TypographyType = 'display' | 'heading' | 'title' | 'label' | 'body' | 'overline';
 

--- a/src/components/atoms/Typography/utils/getStyleByTypography/index.test.ts
+++ b/src/components/atoms/Typography/utils/getStyleByTypography/index.test.ts
@@ -1,0 +1,70 @@
+import {StyleSheet} from 'react-native';
+import getStyleByTypography, {defaultStyles} from './';
+import typography from 'theme/typography';
+
+describe('getStyleByType function', () => {
+	describe('returns default typography', () => {
+		it('as there is no valid type', () => {
+			const styles = getStyleByTypography('invalid', 'invalid');
+
+			expect(styles).toEqual(defaultStyles);
+		});
+
+		it('as there is no valid size', () => {
+			const styles = getStyleByTypography('body', 'invalid');
+
+			expect(styles).toEqual(defaultStyles);
+		});
+
+		it('as there is title type with invalid size', () => {
+			const styles = getStyleByTypography('title', 'invalid');
+
+			expect(styles).toEqual(defaultStyles);
+		});
+	});
+
+	describe('returns typography correctly', () => {
+		it('as there is display type', () => {
+			const styles = getStyleByTypography('display', 'medium');
+
+			expect(styles).toEqual(
+				StyleSheet.create({
+					typography: {
+						fontWeight: typography.display.weight,
+						fontSize: typography.display.size,
+						lineHeight: typography.display.lineHeight,
+					},
+				})
+			);
+		});
+
+		it('as there is overline type with invalid size', () => {
+			const styles = getStyleByTypography('overline', 'medium');
+
+			expect(styles).toEqual(
+				StyleSheet.create({
+					typography: {
+						fontWeight: typography.overline.large.weight,
+						fontSize: typography.overline.large.size,
+						lineHeight: typography.overline.large.lineHeight,
+						letterSpacing: typography.overline.large.spacing,
+					},
+				})
+			);
+		});
+
+		it('as there is title type with valid size', () => {
+			const styles = getStyleByTypography('title', 'large');
+
+			expect(styles).toEqual(
+				StyleSheet.create({
+					typography: {
+						fontWeight: typography.title.large.weight,
+						fontSize: typography.title.large.size,
+						lineHeight: typography.title.large.lineHeight,
+					},
+				})
+			);
+		});
+	});
+});

--- a/src/components/atoms/Typography/utils/getStyleByTypography/index.ts
+++ b/src/components/atoms/Typography/utils/getStyleByTypography/index.ts
@@ -1,14 +1,13 @@
 import {StyleSheet, TextStyle} from 'react-native';
-import typography, {Typography, TypographyItem} from 'theme/typography';
+import typography, {Typography} from 'theme/typography';
 
-// Define valid types and sizes
 type TypographyType = keyof Typography;
 type TypographySize = 'large' | 'medium' | 'small';
 
 const validTypes: TypographyType[] = Object.keys(typography) as TypographyType[];
 const validSizes: TypographySize[] = ['large', 'medium', 'small'];
 
-const defaultStyles = StyleSheet.create<{typography: TextStyle}>({
+export const defaultStyles = StyleSheet.create<{typography: TextStyle}>({
 	typography: {
 		fontWeight: typography.body.medium.weight,
 		fontSize: typography.body.medium.size,
@@ -49,11 +48,9 @@ const getStyleByTypography = (type: TypographyType | string, size: TypographySiz
 	}
 
 	const typographyObject = typography[typographyType];
-	if (typographySize in typographyObject) {
-		const typographyStyle = typographyObject[
-			typographySize as keyof typeof typographyObject
-		] as TypographyItem;
-
+	// istanbul ignore next
+	if (typographyObject && typographySize in typographyObject) {
+		const typographyStyle = typographyObject[typographySize as keyof typeof typographyObject];
 		return StyleSheet.create({
 			typography: {
 				fontWeight: typographyStyle.weight,
@@ -64,6 +61,7 @@ const getStyleByTypography = (type: TypographyType | string, size: TypographySiz
 		});
 	}
 
+	// istanbul ignore next
 	return defaultStyles;
 };
 

--- a/src/components/molecules/Avatar/index.tsx
+++ b/src/components/molecules/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {StyleSheet, View, ViewStyle} from 'react-native';
 import Image from 'atoms/Image';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {formatPlaceholder} from './utils/formatPlaceholder/index';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 
@@ -102,7 +102,9 @@ const Avatar = ({
 			)}
 
 			{(showInitials || !imageUrl) && !!initials.length && (
-				<Text style={[styles.text, {color: textColor, fontSize: validFontSize}]}>{initials}</Text>
+				<Typography style={[styles.text, {color: textColor, fontSize: validFontSize}]}>
+					{initials}
+				</Typography>
 			)}
 		</View>
 	);

--- a/src/components/molecules/Avatar/index.tsx
+++ b/src/components/molecules/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import {StyleSheet, View, ViewStyle} from 'react-native';
 import Image from 'atoms/Image';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {formatPlaceholder} from './utils/formatPlaceholder/index';
 import {horizontalScale, moderateScale, scaledForDevice} from 'scale';
 

--- a/src/components/molecules/Button/index.tsx
+++ b/src/components/molecules/Button/index.tsx
@@ -3,7 +3,7 @@ import {ViewStyle, StyleSheet, TextStyle, View} from 'react-native';
 import BaseButton, {BaseButtonProps} from 'atoms/BaseButton';
 import getButtonStyles from './utils/getButtonStyles';
 import Loading from 'atoms/Loading';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import Icon from 'atoms/Icon';
 
 export const types = {

--- a/src/components/molecules/Button/index.tsx
+++ b/src/components/molecules/Button/index.tsx
@@ -3,7 +3,7 @@ import {ViewStyle, StyleSheet, TextStyle, View} from 'react-native';
 import BaseButton, {BaseButtonProps} from 'atoms/BaseButton';
 import getButtonStyles from './utils/getButtonStyles';
 import Loading from 'atoms/Loading';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import Icon from 'atoms/Icon';
 
 export const types = {
@@ -98,7 +98,7 @@ const Button: FC<ButtonProps> = ({
 	const WrapperComponent = (
 		<View style={styles.direction}>
 			{icon && <Icon name={icon} style={[styles.icon, iconStyle]} size={24} />}
-			{!!value && <Text style={[styles.text, textStyle]}>{value}</Text>}
+			{!!value && <Typography style={[styles.text, textStyle]}>{value}</Typography>}
 		</View>
 	);
 

--- a/src/components/molecules/Carousel/index.test.tsx
+++ b/src/components/molecules/Carousel/index.test.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import {create} from 'react-test-renderer';
 import {ScrollView} from 'react-native';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import Carousel from './';
 
-const validPages = [<Text>Page1</Text>, <Text>Page2</Text>, <Text>Page3</Text>];
+const validPages = [
+	<Typography>Page1</Typography>,
+	<Typography>Page2</Typography>,
+	<Typography>Page3</Typography>,
+];
 const validProps = {
 	pages: validPages,
 	isLoop: true,

--- a/src/components/molecules/Carousel/index.test.tsx
+++ b/src/components/molecules/Carousel/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {create} from 'react-test-renderer';
 import {ScrollView} from 'react-native';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import Carousel from './';
 
 const validPages = [<Text>Page1</Text>, <Text>Page2</Text>, <Text>Page3</Text>];

--- a/src/components/molecules/Carousel/utils/index.test.tsx
+++ b/src/components/molecules/Carousel/utils/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {renderHook} from '@testing-library/react-hooks';
 import useCarouselControls from './';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 
 const validPages = [<Text>Page1</Text>, <Text>Page2</Text>, <Text>Page3</Text>];
 const validProps = {

--- a/src/components/molecules/Carousel/utils/index.test.tsx
+++ b/src/components/molecules/Carousel/utils/index.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import {renderHook} from '@testing-library/react-hooks';
 import useCarouselControls from './';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 
-const validPages = [<Text>Page1</Text>, <Text>Page2</Text>, <Text>Page3</Text>];
+const validPages = [
+	<Typography>Page1</Typography>,
+	<Typography>Page2</Typography>,
+	<Typography>Page3</Typography>,
+];
 const validProps = {
 	pages: validPages,
 	isLoop: true,

--- a/src/components/molecules/Carousel/utils/index.ts
+++ b/src/components/molecules/Carousel/utils/index.ts
@@ -14,7 +14,7 @@ const useCarouselControls = ({
 }: CarouselProps) => {
 	const [activePage, setActivePage] = useState(0);
 	const slider = useRef<ScrollView | null>(null);
-	const intervalId = useRef<number | null>(null);
+	const intervalId = useRef<any | number | null>(null);
 
 	const {width: screenWidth} = Dimensions.get('screen');
 	const width = customWidth ?? screenWidth;

--- a/src/components/molecules/Select/Components/Dropdown/index.test.tsx
+++ b/src/components/molecules/Select/Components/Dropdown/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import Dropdown from './';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {Pressable} from 'react-native';
 
 const validData = {

--- a/src/components/molecules/Select/Components/Dropdown/index.test.tsx
+++ b/src/components/molecules/Select/Components/Dropdown/index.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import Dropdown from './';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {Pressable} from 'react-native';
 
 const validData = {
 	show: true,
 	setShow: () => {},
-	children: <Text>Option 1</Text>,
+	children: <Typography>Option 1</Typography>,
 	measures: {
 		width: 0,
 		pageY: 0,

--- a/src/components/molecules/Select/Components/Modal/index.test.tsx
+++ b/src/components/molecules/Select/Components/Modal/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import BaseButton from 'atoms/BaseButton';
 import Modal from './';
 

--- a/src/components/molecules/Select/Components/Modal/index.test.tsx
+++ b/src/components/molecules/Select/Components/Modal/index.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import BaseButton from 'atoms/BaseButton';
 import Modal from './';
 
 const validData = {
 	show: true,
 	setShow: () => {},
-	children: <Text>Option 1</Text>,
+	children: <Typography>Option 1</Typography>,
 	measures: {
 		width: 0,
 		pageY: 0,

--- a/src/components/molecules/Select/Components/SwitcherComponent/index.test.tsx
+++ b/src/components/molecules/Select/Components/SwitcherComponent/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {VariantOptions} from '../../';
 import SwitcherComponent from './';
 
@@ -13,7 +13,7 @@ const validData = {
 		pageY: 0,
 		pageX: 0,
 	},
-	children: <Text>Text</Text>,
+	children: <Typography>Text</Typography>,
 	modalAcceptText: 'Accept Button',
 	setShow: () => {},
 };

--- a/src/components/molecules/Select/Components/SwitcherComponent/index.test.tsx
+++ b/src/components/molecules/Select/Components/SwitcherComponent/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {VariantOptions} from '../../';
 import SwitcherComponent from './';
 

--- a/src/components/molecules/SwipeList/index.test.tsx
+++ b/src/components/molecules/SwipeList/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import SwipeList from './';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import SwipeUp from 'atoms/SwipeUp';
 
 describe('SwipeList component', () => {
@@ -16,7 +16,7 @@ describe('SwipeList component', () => {
 		it('as it does not have actions nor header', () => {
 			const {root} = create(
 				<SwipeList>
-					<Text>Hola</Text>
+					<Typography>Hola</Typography>
 				</SwipeList>
 			);
 
@@ -28,12 +28,12 @@ describe('SwipeList component', () => {
 		});
 
 		it('as it has all its possible props', () => {
-			const renderHeader = () => <Text>Header</Text>;
+			const renderHeader = () => <Typography>Header</Typography>;
 			const actions = [{value: 'Continuar'}];
 
 			const {root} = create(
 				<SwipeList renderHeader={renderHeader} actions={actions}>
-					<Text>Hola</Text>
+					<Typography>Hola</Typography>
 				</SwipeList>
 			);
 

--- a/src/components/molecules/SwipeList/index.test.tsx
+++ b/src/components/molecules/SwipeList/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {create} from 'react-test-renderer';
 import SwipeList from './';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import SwipeUp from 'atoms/SwipeUp';
 
 describe('SwipeList component', () => {

--- a/src/components/molecules/Tabs/index.tsx
+++ b/src/components/molecules/Tabs/index.tsx
@@ -4,7 +4,7 @@ import {StyleSheet, View, ViewStyle, ScrollView, FlatList} from 'react-native';
 import {moderateScale, scaledForDevice, viewportWidth} from 'scale';
 import {base, black, grey, primary} from 'theme/palette';
 import BaseButton from 'atoms/BaseButton';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {isObject} from 'utils';
 
 type Data = Scene[] | null | undefined;

--- a/src/components/molecules/Tabs/index.tsx
+++ b/src/components/molecules/Tabs/index.tsx
@@ -4,7 +4,7 @@ import {StyleSheet, View, ViewStyle, ScrollView, FlatList} from 'react-native';
 import {moderateScale, scaledForDevice, viewportWidth} from 'scale';
 import {base, black, grey, primary} from 'theme/palette';
 import BaseButton from 'atoms/BaseButton';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {isObject} from 'utils';
 
 type Data = Scene[] | null | undefined;
@@ -149,9 +149,12 @@ const Tabs: FC<TabsProps> = ({
 				style={{...styles.tabButton, borderBottomColor}}
 				disabled={disabled}
 				onPress={() => handleOnPress(index)}>
-				<Text style={{...styles.title, color: textColor}} selectable={false} numberOfLines={1}>
+				<Typography
+					style={{...styles.title, color: textColor}}
+					selectable={false}
+					numberOfLines={1}>
 					{title}
-				</Text>
+				</Typography>
 			</BaseButton>
 		);
 	};

--- a/src/components/molecules/Toast/index.test.tsx
+++ b/src/components/molecules/Toast/index.test.tsx
@@ -3,7 +3,7 @@ import {TouchableOpacity} from 'react-native';
 import {create} from 'react-test-renderer';
 import Toast from './';
 import {Types} from 'atoms/BaseToast';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 
 const props1 = {
 	showIcon: true,
@@ -24,7 +24,7 @@ const validProps = {
 	text2: 'Message toast',
 	type: Types.Notice,
 	style: {color: 'blue'},
-	children: <Text>Text</Text>,
+	children: <Typography>Text</Typography>,
 };
 
 describe('Toast', () => {

--- a/src/components/molecules/Toast/index.test.tsx
+++ b/src/components/molecules/Toast/index.test.tsx
@@ -3,7 +3,7 @@ import {TouchableOpacity} from 'react-native';
 import {create} from 'react-test-renderer';
 import Toast from './';
 import {Types} from 'atoms/BaseToast';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 
 const props1 = {
 	showIcon: true,

--- a/src/components/molecules/Toast/index.tsx
+++ b/src/components/molecules/Toast/index.tsx
@@ -6,7 +6,7 @@ import {defaultIcon} from './utils';
 import {base, black} from 'theme/palette';
 import BaseToast, {BaseToastProps} from 'atoms/BaseToast';
 import ToastAction from 'react-native-toast-message';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import Icon from 'atoms/Icon';
 
 export interface ToastProps extends BaseToastProps {

--- a/src/components/molecules/Toast/index.tsx
+++ b/src/components/molecules/Toast/index.tsx
@@ -6,7 +6,7 @@ import {defaultIcon} from './utils';
 import {base, black} from 'theme/palette';
 import BaseToast, {BaseToastProps} from 'atoms/BaseToast';
 import ToastAction from 'react-native-toast-message';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import Icon from 'atoms/Icon';
 
 export interface ToastProps extends BaseToastProps {
@@ -114,8 +114,8 @@ const Toast: FC<ToastProps> = ({type, text1, text2, style, props}) => {
 			)}
 
 			<View style={styles.textWrapper}>
-				{validTitle && <Text style={styles.title}>{text1}</Text>}
-				{validMessage && <Text style={styles.message}>{text2}</Text>}
+				{validTitle && <Typography style={styles.title}>{text1}</Typography>}
+				{validMessage && <Typography style={styles.message}>{text2}</Typography>}
 			</View>
 
 			<View style={styles.feedbackWrapper}>
@@ -124,7 +124,7 @@ const Toast: FC<ToastProps> = ({type, text1, text2, style, props}) => {
 						style={styles.actionWrapper}
 						onPress={handleActionCb}
 						activeOpacity={0.6}>
-						<Text style={styles.actionTitle}>{actionTitle}</Text>
+						<Typography style={styles.actionTitle}>{actionTitle}</Typography>
 					</TouchableOpacity>
 				)}
 				{showCloseIcon && (

--- a/src/components/molecules/Toast/utils/index.test.tsx
+++ b/src/components/molecules/Toast/utils/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from '@testing-library/react-native';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 import {configToast} from './'; // Ajusta la ruta según sea necesario
 
 // Mocks
@@ -9,7 +9,7 @@ jest.mock('../', () => {
 });
 
 describe('configToast', () => {
-	const mockProps = {title1: 'Test message', children: <Text>Title</Text>};
+	const mockProps = {title1: 'Test message', children: <Typography>Title</Typography>};
 
 	it('should render success Toast correctly', () => {
 		const {toJSON} = render(configToast.success(mockProps));

--- a/src/components/molecules/Toast/utils/index.test.tsx
+++ b/src/components/molecules/Toast/utils/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {render} from '@testing-library/react-native';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 import {configToast} from './'; // Ajusta la ruta según sea necesario
 
 // Mocks

--- a/src/components/organisms/FullScreenMessage/index.tsx
+++ b/src/components/organisms/FullScreenMessage/index.tsx
@@ -3,7 +3,7 @@ import {Modal, StyleSheet, View} from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
 import {base, primary} from 'theme/palette';
 import Icon from 'atoms/Icon';
-import Text from 'atoms/Text';
+import Text from 'atoms/Typography';
 
 export enum animationTypes {
 	Slide = 'slide',

--- a/src/components/organisms/FullScreenMessage/index.tsx
+++ b/src/components/organisms/FullScreenMessage/index.tsx
@@ -3,7 +3,7 @@ import {Modal, StyleSheet, View} from 'react-native';
 import {moderateScale, scaledForDevice} from 'scale';
 import {base, primary} from 'theme/palette';
 import Icon from 'atoms/Icon';
-import Text from 'atoms/Typography';
+import Typography from 'atoms/Typography';
 
 export enum animationTypes {
 	Slide = 'slide',
@@ -94,8 +94,8 @@ const FullScreenMessage: FC<Props> = ({
 			<View style={styles.container}>
 				{children ?? (
 					<>
-						{validTitle && <Text style={styles.title}>{title}</Text>}
-						{validSubtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
+						{validTitle && <Typography style={styles.title}>{title}</Typography>}
+						{validSubtitle && <Typography style={styles.subtitle}>{subtitle}</Typography>}
 						{validIconName && <Icon color={iconColor} size={130} name={iconName} />}
 					</>
 				)}

--- a/src/components/organisms/SwipeItemSelectionList/index.tsx
+++ b/src/components/organisms/SwipeItemSelectionList/index.tsx
@@ -62,6 +62,7 @@ const SwipeItemSelectionList: React.FC<SwipeItemSelectionListProps> = React.forw
 
 			return (
 				<ItemSelectionButton
+					key={id}
 					radioButton={radioButton}
 					leftSelection={leftSelection}
 					rightSelection={rightSelection}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import Svg from 'atoms/Svg';
 import SwipeUp from 'atoms/SwipeUp';
 import {SwipeUpFlatList, SwipeUpScrollView, SwipeUpView} from 'atoms/SwipeUp/childComponents';
 import Text from 'atoms/Text';
+import Typography from 'atoms/Typography';
 
 // Molecules
 import Avatar from 'molecules/Avatar';
@@ -61,4 +62,5 @@ export {
 	Toast,
 	configToast,
 	SwipeList,
+	Typography,
 };

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,64 @@
+export type TypographyItem = {
+	weight: '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+	size: number;
+	lineHeight: number;
+	spacing?: number;
+};
+
+export type Typography = {
+	display: TypographyItem;
+	heading: {
+		large: TypographyItem;
+		medium: TypographyItem;
+		small: TypographyItem;
+	};
+	title: {
+		large: TypographyItem;
+		medium: TypographyItem;
+		small: TypographyItem;
+	};
+	label: {
+		large: TypographyItem;
+		medium: TypographyItem;
+		small: TypographyItem;
+	};
+	body: {
+		large: TypographyItem;
+		medium: TypographyItem;
+		small: TypographyItem;
+	};
+	overline: {
+		large: TypographyItem;
+		small: TypographyItem;
+	};
+};
+
+const typography: Typography = {
+	display: {weight: '400', size: 42, lineHeight: 50},
+	heading: {
+		large: {weight: '500', size: 34, lineHeight: 40},
+		medium: {weight: '500', size: 26, lineHeight: 32},
+		small: {weight: '400', size: 24, lineHeight: 28},
+	},
+	title: {
+		large: {weight: '400', size: 20, lineHeight: 24},
+		medium: {weight: '700', size: 18, lineHeight: 22},
+		small: {weight: '700', size: 14, lineHeight: 16},
+	},
+	label: {
+		large: {weight: '500', size: 16, lineHeight: 18},
+		medium: {weight: '500', size: 14, lineHeight: 16},
+		small: {weight: '500', size: 12, lineHeight: 14},
+	},
+	body: {
+		large: {weight: '400', size: 16, lineHeight: 20},
+		medium: {weight: '400', size: 14, lineHeight: 18},
+		small: {weight: '400', size: 12, lineHeight: 16},
+	},
+	overline: {
+		large: {weight: '500', size: 14, lineHeight: 16, spacing: 1},
+		small: {weight: '500', size: 12, lineHeight: 14, spacing: 0.7},
+	},
+};
+
+export default typography;

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,1 +1,7 @@
 export const isObject = (obj: Object) => !!(obj && obj.constructor === Object);
+
+export const isDevEnv = () => {
+	const {env} = process;
+	const {NODE_ENV} = env;
+	return NODE_ENV !== 'production';
+};

--- a/storybook/decorators/DeprecationNotice/index.js
+++ b/storybook/decorators/DeprecationNotice/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import {StyleSheet, View, Text, Image} from 'react-native';
+
+const DeprecationNotice = ({children}) => {
+	return (
+		<View style={styles.main}>
+			<View style={styles.deprecationCard}>
+				<Image
+					style={styles.deprecationImage}
+					source={{
+						uri: 'https://static.vecteezy.com/system/resources/thumbnails/012/042/301/small_2x/warning-sign-icon-transparent-background-free-png.png',
+					}}
+				/>
+
+				<Text style={styles.deprecationText}>This component is going to be deprecated soon.</Text>
+			</View>
+			<View style={styles.story}>{children}</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	main: {
+		flex: 1,
+		display: 'flex',
+		flexDirection: 'column',
+	},
+	deprecationCard: {
+		display: 'flex',
+		flexDirection: 'row',
+		borderColor: '#2979FF',
+		backgroundColor: '#2979FF',
+		borderWidth: 1,
+		borderRadius: 5,
+		padding: 10,
+		justifyContent: 'center',
+		alignItems: 'center',
+		gap: 5,
+	},
+	deprecationImage: {
+		width: 20,
+		height: 20,
+	},
+	deprecationText: {
+		color: 'white',
+	},
+	story: {
+		flex: 1,
+		display: 'flex',
+		flexDirection: 'column',
+		justifyContent: 'center',
+		alignItems: 'center',
+		marginTop: 50,
+	},
+});
+
+export default DeprecationNotice;

--- a/storybook/stories/Text/Text.stories.js
+++ b/storybook/stories/Text/Text.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Text from 'atoms/Text';
+import DeprecationNotice from '../../decorators/DeprecationNotice';
 
 const fontFamilies = [
 	'normal',
@@ -54,6 +55,13 @@ export default {
 			control: {type: 'color'},
 		},
 	},
+	decorators: [
+		(Story) => (
+			<DeprecationNotice>
+				<Story />
+			</DeprecationNotice>
+		),
+	],
 };
 
 export const DefaultProps = ({

--- a/storybook/stories/Typography/Typography.stories.js
+++ b/storybook/stories/Typography/Typography.stories.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Typography from 'atoms/Typography';
+import typography from 'theme/typography';
+
+const types = Array.from(Object.keys(typography));
+
+const sizes = ['large', 'medium', 'small'];
+
+export default {
+	title: 'Components/Typography',
+	argTypes: {
+		type: {
+			options: types,
+			control: {type: 'select'},
+		},
+		size: {
+			options: sizes,
+			control: {type: 'select'},
+		},
+		color: {
+			control: {type: 'color'},
+		},
+	},
+};
+
+export const DefaultProps = ({textToDisplay, color, type, size}) => (
+	<Typography color={color} type={type} size={size}>
+		{textToDisplay}
+	</Typography>
+);
+
+DefaultProps.storyName = 'default props';
+
+DefaultProps.args = {
+	textToDisplay: 'Hola',
+	color: '#000000',
+	type: 'display',
+	size: 'medium',
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
 		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"baseUrl": "./src",
-		"types": ["react", "react-native", "jest"],
+		"types": ["react", "react-native", "jest", "node"],
 		"paths": {
 			"react": ["../node_modules/@types/react"],
 			"atoms/*": ["./components/atoms/*"],


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-340

DESCRIPCIÓN DEL REQUERIMIENTO:
Actualmente contamos con un componente Text que se encarga de renderizar el texto y nos permite modificar sus estilos para adaptarlo a nuestras necesidades, recientemente, desde diseño, se [establecieron ciertas tipografías](https://www.figma.com/design/FLybyH52rc4EapUG1qjMPc/Design-System?node-id=5441-16450&node-type=frame&t=8zyJDEs6SCPFMPwL-0) que serán las que van a estar siendo usadas a lo largo de todas las apps, desde el lado de diseño también van a estar estableciendo el tipo y tamaño de esta tipografía a partir de la guía, por lo que, esto nos abre la posibilidad para implementar directamente en un componente la implementación de estas tipografías de manera tal que sean más faciles de usar, para no tener que estar haciendo uso de las tipografías manualmente.

DESCRIPCIÓN DE LA SOLUCIÓN:
Se añadió el componente Typography, el cuál, a partir de las props de type y size que se le pasen renderiza el texto con los estilos que cumplen el diseño establecido en la guía de figma

CÓMO SE PUEDE PROBAR?
Vinculando el package con algún repo de las apps: https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI

Y probando que las distintas tipografías de los textos funcionen correctamente.