### PR TITLE
Hotfix/añadir sombra a componente basecardlist

### DIFF
--- a/src/components/atoms/BaseCardList/index.tsx
+++ b/src/components/atoms/BaseCardList/index.tsx
@@ -1,0 +1,42 @@
+import React, {FC, ReactNode} from 'react';
+import {StyleSheet, View, ViewProps} from 'react-native';
+import {palette} from 'theme/palette';
+
+export interface BaseCardListProps extends ViewProps {
+	children: ReactNode;
+	isSelected?: boolean;
+}
+
+const BaseCardList: FC<BaseCardListProps> = ({children, isSelected = false, style, ...props}) => {
+	if (!children) {
+		return null;
+	}
+
+	const styles = StyleSheet.create({
+		container: {
+			backgroundColor: palette.base.white,
+			borderRadius: 20,
+			width: '100%',
+			padding: 16,
+			elevation: 5,
+		},
+		selectedContainer: {
+			borderWidth: 2,
+			borderColor: palette.primary.main,
+		},
+	});
+
+	const activeStyles = [
+		styles.container,
+		isSelected && styles.selectedContainer,
+		style && style,
+	].filter(Boolean);
+
+	return (
+		<View style={activeStyles} {...props}>
+			{children}
+		</View>
+	);
+};
+
+export default BaseCardList;


### PR DESCRIPTION
DESCRIPCIÓN DEL REQUERIMIENTO:
Se requiere añadir sombra al componente BaseCardList para que quede según diseño

DESCRIPCIÓN DE LA SOLUCIÓN:
Se añadió en el estilo del container de BaseCardList la prop elevation: 5

CÓMO SE PUEDE PROBAR?
Revisando que la sombra se vea correctamente en el componente