### PR TITLE
fixed maincard shadow styles

### DIFF
--- a/src/components/atoms/BaseCardList/index.tsx
+++ b/src/components/atoms/BaseCardList/index.tsx
@@ -18,11 +18,14 @@ const BaseCardList: FC<BaseCardListProps> = ({children, isSelected = false, styl
 			borderRadius: 20,
 			width: '100%',
 			padding: 16,
-			elevation: 5,
+			elevation: 2,
+			shadowColor: palette.black.main,
 		},
 		selectedContainer: {
 			borderWidth: 2,
 			borderColor: palette.primary.main,
+			elevation: 4,
+			shadowColor: palette.primary.main,
 		},
 	});
 


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/JUIP-160

LINK DE SUBTAREA;
https://janiscommerce.atlassian.net/browse/JUIP-161

DESCRIPCIÓN DEL REQUERIMIENTO

La veo muy fuerte a la sombra, deberia cumplir con los estilos del Design System. Además cuando se selecciona la card, la sombra deberia ser azul, no gris.

Asi se ve:
<img width="353" alt="001" src="https://github.com/user-attachments/assets/c5d4072b-c9fc-4ea3-b88d-9239af35768f">

En los margenes queda cortada la sombra…
<img width="146" alt="002" src="https://github.com/user-attachments/assets/941bd8cb-4de8-4744-82d6-3433817c6e8e">


Asi deberia estar:
![003](https://github.com/user-attachments/assets/8fcb763d-9334-414d-9574-8f098a9de2ad)

DESCRIPCIÓN DE LA SOLUCIÓN:

Se modificaron los valores de elevation para las maincard, pasandolo a 2 cuando está sin seleccionar, y a 4 cuando se encuentra seleccionada. además se agregaron colores para cada caso de sombra:
 - primary.main para cuando está seleccionada.
 - black.main para cuando está en reposo.

Respecto a lo que marcó el equipo de diseño sobre los bordes cortados, esto es más un problema de la implementación que del componente, ya que en el storybook de android se ve bien.