### PR TITLE
Fixed typography on FullScreenMessage component

### DIFF
--- a/src/components/organisms/FullScreenMessage/index.tsx
+++ b/src/components/organisms/FullScreenMessage/index.tsx
@@ -94,8 +94,16 @@ const FullScreenMessage: FC<Props> = ({
 			<View style={styles.container}>
 				{children ?? (
 					<>
-						{validTitle && <Typography style={styles.title}>{title}</Typography>}
-						{validSubtitle && <Typography style={styles.subtitle}>{subtitle}</Typography>}
+						{validTitle && (
+							<Typography style={styles.title} type="heading" size="large">
+								{title}
+							</Typography>
+						)}
+						{validSubtitle && (
+							<Typography style={styles.subtitle} type="body" size="large">
+								{subtitle}
+							</Typography>
+						)}
 						{validIconName && <Icon color={iconColor} size={130} name={iconName} />}
 					</>
 				)}


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/JUIP-165 

DESCRIPCIÓN DEL REQUERIMIENTO: *

Se requiere corregir la tipografía del componente FullScreenMessage para que quede según [diseño](https://www.figma.com/design/ZWLyF29DMLh5ywkBnuHVZi/Delivery-App?node-id=14184-33384&t=hdkscmt1sebKutWM-0)

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se añadieron las props type y size para los dos componentes Typography que se emplearon dentro del componente FullScreenMessage para que los mismos sean iguales a los que se usaron en el diseño

CÓMO SE PUEDE PROBAR? *

Verificando que la tipografía sea la misma que la del diseño

SCREENSHOTS:

Antes:

![Screenshot_1734980021](https://github.com/user-attachments/assets/977848a0-9724-4e36-be6b-a00575ee55ca)


Después:

![Screenshot_1734979986](https://github.com/user-attachments/assets/39c1b309-dad3-42a0-89c3-8385d4241af9)


DATOS EXTRA A TENER EN CUENTA: