### PR TITLE
Made adjustments to Input component

### DIFF
--- a/src/components/molecules/Input/index.test.tsx
+++ b/src/components/molecules/Input/index.test.tsx
@@ -63,6 +63,14 @@ describe('Input Component', () => {
 			expect(onChangeTextMock).toHaveBeenCalledWith('new text');
 		});
 
+		it('and do not call changeTextCb when text is changed as there is not one', () => {
+			const onChangeTextMock = jest.fn();
+			const {getByPlaceholderText} = render(<Input placeholder="Enter text" type="text" />);
+			const input = getByPlaceholderText('Enter text');
+			fireEvent.changeText(input, 'new text');
+			expect(onChangeTextMock).toHaveBeenCalledTimes(0);
+		});
+
 		it('as it is amountTotal type and is pressed', () => {
 			const {getByText} = render(<Input type="text" variant="amountTotal" totalValue={6} />);
 			const input = getByText('/6');

--- a/src/components/molecules/Input/utils/handleChangeText/index.test.ts
+++ b/src/components/molecules/Input/utils/handleChangeText/index.test.ts
@@ -1,49 +1,51 @@
 import {InputVariant} from 'molecules/Input';
 import handleChangeText from './';
 
-const mockSetValue = jest.fn();
-const mockOnChangeText = jest.fn();
-
 describe('Input handleChangeText util', () => {
 	describe('returns untransformed text', () => {
 		it('as there is an invalid variant', () => {
-			handleChangeText('ABC', mockSetValue, 'invalid' as InputVariant, mockOnChangeText);
+			const initialValue = 'ABC';
+			const transformedValue = handleChangeText(initialValue, 'invalid' as InputVariant);
 
-			expect(mockSetValue).toBeCalledWith('ABC');
-			expect(mockOnChangeText).toBeCalled();
+			expect(transformedValue).toEqual(initialValue);
 		});
 	});
 
 	describe('returns transformed text', () => {
 		it('as it is a weightable variant', () => {
-			handleChangeText('10,0', mockSetValue, 'weightable');
+			const initialValue = '10,0';
+			const transformedValue = handleChangeText(initialValue, 'weightable');
 
-			expect(mockSetValue).toBeCalledWith('10.0');
+			const expectedValue = '10.0';
+
+			expect(transformedValue).toEqual(expectedValue);
 		});
 
 		it('as it is a amountTotal variant', () => {
-			handleChangeText('10', mockSetValue, 'amountTotal');
+			const initialValue = '10';
+			const transformedValue = handleChangeText(initialValue, 'amountTotal');
 
-			expect(mockSetValue).toBeCalledWith('10');
+			const expectedValue = '10';
+
+			expect(transformedValue).toEqual(expectedValue);
 		});
 
 		it('as it is a currency variant', () => {
-			handleChangeText('10', mockSetValue, 'currency');
+			const initialValue = '10';
+			const transformedValue = handleChangeText(initialValue, 'currency');
 
-			expect(mockSetValue).toBeCalledWith('10');
+			const expectedValue = '10';
+
+			expect(transformedValue).toEqual(expectedValue);
 		});
 
 		it('as it is a numeric variant', () => {
-			handleChangeText('10', mockSetValue, 'numeric');
+			const initialValue = '10';
+			const transformedValue = handleChangeText(initialValue, 'numeric');
 
-			expect(mockSetValue).toBeCalledWith('10');
-		});
+			const expectedValue = '10';
 
-		it('as there is a valid variant and a valid onChangeText', () => {
-			handleChangeText('10,0', mockSetValue, 'weightable', mockOnChangeText);
-
-			expect(mockSetValue).toBeCalledWith('10.0');
-			expect(mockOnChangeText).toBeCalled();
+			expect(transformedValue).toEqual(expectedValue);
 		});
 	});
 });

--- a/src/components/molecules/Input/utils/handleChangeText/index.ts
+++ b/src/components/molecules/Input/utils/handleChangeText/index.ts
@@ -1,5 +1,4 @@
 import {InputVariant} from 'molecules/Input';
-import {Dispatch, SetStateAction} from 'react';
 
 type VariantLogic = Record<InputVariant, (value: string) => string>;
 
@@ -16,19 +15,10 @@ const transformText = (text: string, variant: InputVariant): string => {
 	return transform(text);
 };
 
-const handleChangeText = (
-	text: string,
-	setValue: Dispatch<SetStateAction<string>>,
-	variant: InputVariant,
-	onChangeText?: (text: string) => void
-): void => {
+const handleChangeText = (text: string, variant: InputVariant): string => {
 	const transformedText = transformText(text, variant);
 
-	setValue(transformedText);
-
-	if (onChangeText) {
-		onChangeText(transformedText);
-	}
+	return transformedText;
 };
 
 export default handleChangeText;

--- a/storybook/stories/Input/Input.stories.js
+++ b/storybook/stories/Input/Input.stories.js
@@ -34,4 +34,5 @@ DefaultProps.args = {
 	placeholder: 'Placeholder example',
 	type: 'text',
 	variant: 'default',
+	totalValue: 6,
 };


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-359

DESCRIPCIÓN DEL REQUERIMIENTO: *

Ya contamos con el nuevo componente Input dentro de UI-Native, pero se observaron ciertos ajustes a realizar dentro del mismo, por lo que esto es lo que se buscó encarar dentro de este desarrollo

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se eliminó la función para settear el ref externo del componente, reemplazandolo por las siguientes líneas de código:

`const internalRef = useRef<TextInput>(null);
  const inputRef = ref ?? internalRef;`

Se modificó la util handleChangeText del componente para que acepte dos argumentos en vez de cuatro, devuelva el valor transformado que se le haya pasado y, dentro del componente Input, se comenzó a settear el state y a llamar a la función onChangeText si es que la misma está presente

Se realizó un ajuste visto en Storybook en dónde no estaba disponible la prop "totalValue" para ser modificada, lo que hacía que no se mostrará el Input cuándo se seleccionaba el tipo "amountTotal"

CÓMO SE PUEDE PROBAR? *

Revisando el código, linkeando el pkg y verificando que el componente siga funcionando correctamente
