### PR TITLE
fixed collapsible rendered height

### DIFF
--- a/src/components/atoms/Collapsible/index.tsx
+++ b/src/components/atoms/Collapsible/index.tsx
@@ -56,7 +56,6 @@ const Collapsible: React.FC<CollapsibleProps<{isOpen: boolean}, {isOpen?: boolea
 
 	const styles = StyleSheet.create({
 		wrapperView: {
-			flex: 1,
 			width: '100%',
 		},
 		animatedView: {

--- a/src/components/atoms/Collapsible/index.tsx
+++ b/src/components/atoms/Collapsible/index.tsx
@@ -22,17 +22,17 @@ const Collapsible: React.FC<CollapsibleProps<{isOpen: boolean}, {isOpen?: boolea
 	duration = 500,
 	wrapperStyle = {},
 }) => {
-	const isOpen = useSharedValue(false);
+	const [isOpen, setIsOpen] = useState(false);
 	const [measuredHeight, setMeasuredHeight] = useState(0);
 	const contentHeight = useSharedValue(0);
 	const hasHeightBeenMeasured = !!measuredHeight;
 
 	const handleOpen = () => {
 		// istanbul ignore next
-		if (!isOpen.value && measuredHeight > 0) {
+		if (!isOpen && measuredHeight > 0) {
 			contentHeight.value = measuredHeight;
 		}
-		isOpen.value = !isOpen.value;
+		setIsOpen(!isOpen);
 
 		if (onPressCallback) {
 			onPressCallback();
@@ -50,14 +50,12 @@ const Collapsible: React.FC<CollapsibleProps<{isOpen: boolean}, {isOpen?: boolea
 
 	// istanbul ignore next
 	const bodyStyle = useAnimatedStyle(() => ({
-		maxHeight: withTiming(isOpen.value ? contentHeight.value : 0, {duration}),
+		maxHeight: withTiming(isOpen ? contentHeight.value : 0, {duration}),
 		overflow: 'hidden',
 	}));
 
 	const styles = StyleSheet.create({
-		wrapperView: {
-			width: '100%',
-		},
+		wrapperView: {flex: 1, width: '100%'},
 		animatedView: {
 			overflow: 'hidden',
 			width: '100%',
@@ -76,7 +74,7 @@ const Collapsible: React.FC<CollapsibleProps<{isOpen: boolean}, {isOpen?: boolea
 	return (
 		<View style={[wrapperStyle, styles.wrapperView]}>
 			<PressableComponent onPress={handleOpen}>
-				<Header isOpen={isOpen.value} />
+				<Header isOpen={isOpen} />
 			</PressableComponent>
 			{!hasHeightBeenMeasured && (
 				<View style={styles.contentWrapper} onLayout={handleContentLayout}>

--- a/storybook/stories/Collapsible/Collapsible.stories.js
+++ b/storybook/stories/Collapsible/Collapsible.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-native/no-inline-styles */
 import React from 'react';
 import Collapsible from 'atoms/Collapsible';
 import {StyleSheet, View, Text, TouchableOpacity, Image, ScrollView} from 'react-native';
@@ -27,13 +28,50 @@ export const CollapsibleWithText = ({headerTitle, duration}) => {
 	];
 
 	return (
-		<Collapsible
-			header={() => Header({headerTitle})}
-			content={ContentWithText}
-			data={data}
-			duration={duration}
-			pressableComponent={TouchableOpacity}
-		/>
+		<>
+			<Collapsible
+				header={() => Header({headerTitle})}
+				content={ContentWithText}
+				data={data}
+				duration={duration}
+				pressableComponent={TouchableOpacity}
+				wrapperStyle={{
+					paddingBottom: 10,
+				}}
+			/>
+			<Collapsible
+				header={() => Header({headerTitle})}
+				content={ContentWithText}
+				data={data}
+				duration={duration}
+				pressableComponent={TouchableOpacity}
+				wrapperStyle={{
+					paddingBottom: 10,
+				}}
+			/>
+
+			<Collapsible
+				header={() => Header({headerTitle})}
+				content={ContentWithText}
+				data={data}
+				duration={duration}
+				pressableComponent={TouchableOpacity}
+				wrapperStyle={{
+					paddingBottom: 10,
+				}}
+			/>
+
+			<Collapsible
+				header={() => Header({headerTitle})}
+				content={ContentWithText}
+				data={data}
+				duration={duration}
+				pressableComponent={TouchableOpacity}
+				wrapperStyle={{
+					paddingBottom: 10,
+				}}
+			/>
+		</>
 	);
 };
 
@@ -132,8 +170,6 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		backgroundColor: 'white',
 		borderWidth: 1,
-		borderBottomLeftRadius: 15,
-		borderBottomRightRadius: 15,
 	},
 	title: {
 		fontSize: 18,


### PR DESCRIPTION
LINK DE TICKET:

https://janiscommerce.atlassian.net/browse/APPSRN-361

CONTEXTO:

Durante la implementación del componente collapsible de ui-native nos dimos cuenta que, al estar renderizado, el componente desplaza hacia abajo el resto de elementos en pantalla debido a que está tomando, como alto del componente, el alto total de su header + el content que debe renderizar.

NECESIDAD:

Corregir el comportamiento del componente para que, al estar cerrado, no ocupe más lugar que su header correspondiente en pantalla.

SOLUCIÓN:
Se removió la propiedad `flex` de los estilos del wrapper de collapsible

CÓMO PROBARLO?

- Revisar storybooks web o mobile.

![Peek 2025-02-14 16-58](https://github.com/user-attachments/assets/8b454135-c7a7-4fd8-987a-4e3c0fef9a3a)
