### PR TITLE
Added ErrorBoundary component

### DIFF
--- a/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.test.tsx
+++ b/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.test.tsx
@@ -1,39 +1,24 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react-native';
+import {render} from '@testing-library/react-native';
 import ErrorFallback from './index';
 
 describe('ErrorFallback', () => {
-	it('renders heading and fallback text', () => {
-		const {getByText} = render(<ErrorFallback onButtonPress={jest.fn()} />);
+	it('renders errorMessage as it has been passed', () => {
+		const {getByText} = render(<ErrorFallback errorMessage="Something went wrong" />);
+
+		expect(getByText('Something went wrong')).toBeTruthy();
+	});
+
+	it('renders heading, fallback text and collapsible as it is debug', () => {
+		const {getByText} = render(<ErrorFallback isDebug />);
 
 		expect(getByText('Oops! Something went wrong.')).toBeTruthy();
 		expect(getByText('Show error details')).toBeTruthy();
-		expect(getByText('Go Back')).toBeTruthy();
 	});
 
 	it('renders error message if provided', () => {
-		const {getByText} = render(
-			<ErrorFallback error="This is an error" onButtonPress={jest.fn()} />
-		);
+		const {getByText} = render(<ErrorFallback error="This is an error" />);
 
 		expect(getByText('This is an error')).toBeTruthy();
-	});
-
-	it('renders error details if provided', () => {
-		const {getAllByText} = render(
-			<ErrorFallback errorDetails="Stack trace line 1" onButtonPress={jest.fn()} />
-		);
-
-		expect(getAllByText('Stack trace line 1')).toBeTruthy();
-	});
-
-	it('calls onButtonPress when Go Back is pressed', () => {
-		const onButtonPressMock = jest.fn();
-
-		const {getByText} = render(<ErrorFallback onButtonPress={onButtonPressMock} />);
-
-		fireEvent.press(getByText('Go Back'));
-
-		expect(onButtonPressMock).toHaveBeenCalled();
 	});
 });

--- a/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.test.tsx
+++ b/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import ErrorFallback from './index';
+
+describe('ErrorFallback', () => {
+	it('renders heading and fallback text', () => {
+		const {getByText} = render(<ErrorFallback onButtonPress={jest.fn()} />);
+
+		expect(getByText('Oops! Something went wrong.')).toBeTruthy();
+		expect(getByText('Show error details')).toBeTruthy();
+		expect(getByText('Go Back')).toBeTruthy();
+	});
+
+	it('renders error message if provided', () => {
+		const {getByText} = render(
+			<ErrorFallback error="This is an error" onButtonPress={jest.fn()} />
+		);
+
+		expect(getByText('This is an error')).toBeTruthy();
+	});
+
+	it('renders error details if provided', () => {
+		const {getAllByText} = render(
+			<ErrorFallback errorDetails="Stack trace line 1" onButtonPress={jest.fn()} />
+		);
+
+		expect(getAllByText('Stack trace line 1')).toBeTruthy();
+	});
+
+	it('calls onButtonPress when Go Back is pressed', () => {
+		const onButtonPressMock = jest.fn();
+
+		const {getByText} = render(<ErrorFallback onButtonPress={onButtonPressMock} />);
+
+		fireEvent.press(getByText('Go Back'));
+
+		expect(onButtonPressMock).toHaveBeenCalled();
+	});
+});

--- a/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
+++ b/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import Collapsible from 'atoms/Collapsible';
+import Typography from 'atoms/Typography';
+import Button from 'molecules/Button';
+import {StyleSheet, TouchableOpacity, View} from 'react-native';
+import {palette} from 'theme/palette';
+
+interface ErrorFallbackProps {
+	error?: string;
+	errorDetails?: string;
+	onButtonPress: () => void;
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: palette.white.light,
+		padding: 30,
+		borderRadius: 12,
+		margin: 16,
+		shadowColor: palette.base.black,
+		shadowOffset: {width: 0, height: 2},
+		shadowOpacity: 0.2,
+		shadowRadius: 4,
+		elevation: 5,
+	},
+	showErrorButton: {
+		paddingVertical: 10,
+		paddingHorizontal: 20,
+		justifyContent: 'center',
+		alignItems: 'center',
+		backgroundColor: palette.error.main,
+		borderRadius: 6,
+		marginVertical: 12,
+	},
+	collapsibleWrapper: {
+		marginBottom: 35,
+	},
+	errorDetails: {
+		padding: 10,
+		backgroundColor: palette.black.main,
+		borderRadius: 8,
+		marginVertical: 10,
+	},
+	heading: {
+		marginBottom: 12,
+	},
+	goBackButtonWrapper: {
+		marginTop: 20,
+	},
+});
+
+const ErrorFallback: React.FC<ErrorFallbackProps> = ({error, errorDetails, onButtonPress}) => {
+	const ShowErrorDetailsButton = () => {
+		return (
+			<View style={styles.showErrorButton}>
+				<Typography color={palette.base.white}>Show error details</Typography>
+			</View>
+		);
+	};
+
+	const ErrorDetails = ({errorDetails}: any) => {
+		return (
+			<View style={styles.errorDetails}>
+				<Typography color={palette.error.main}>{errorDetails}</Typography>
+			</View>
+		);
+	};
+
+	const data = [
+		{
+			errorDetails,
+		},
+	];
+
+	return (
+		<View style={styles.container}>
+			<Typography type="heading" size="large" style={styles.heading}>
+				Oops! Something went wrong.
+			</Typography>
+			{error && <Typography color={palette.error.main}>{error}</Typography>}
+			<Collapsible
+				wrapperStyle={styles.collapsibleWrapper}
+				header={() => ShowErrorDetailsButton()}
+				content={ErrorDetails}
+				data={data}
+				pressableComponent={TouchableOpacity}
+			/>
+			<View style={styles.goBackButtonWrapper}>
+				<Button value="Go Back" onPress={onButtonPress} />
+			</View>
+		</View>
+	);
+};
+
+export default ErrorFallback;

--- a/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
+++ b/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import Collapsible from 'atoms/Collapsible';
 import Typography from 'atoms/Typography';
-import Button from 'molecules/Button';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {palette} from 'theme/palette';
 
 interface ErrorFallbackProps {
 	error?: string;
 	errorDetails?: string;
-	onButtonPress: () => void;
+	isDebug?: boolean;
+	errorMessage?: string;
 }
 
 const styles = StyleSheet.create({
@@ -25,6 +25,10 @@ const styles = StyleSheet.create({
 		shadowOpacity: 0.2,
 		shadowRadius: 4,
 		elevation: 5,
+	},
+	errorMessageText: {
+		textAlign: 'center',
+		color: palette.error.main,
 	},
 	showErrorButton: {
 		paddingVertical: 10,
@@ -52,7 +56,12 @@ const styles = StyleSheet.create({
 	},
 });
 
-const ErrorFallback: React.FC<ErrorFallbackProps> = ({error, errorDetails, onButtonPress}) => {
+const ErrorFallback: React.FC<ErrorFallbackProps> = ({
+	error,
+	errorDetails,
+	isDebug,
+	errorMessage,
+}) => {
 	const ShowErrorDetailsButton = () => {
 		return (
 			<View style={styles.showErrorButton}>
@@ -75,22 +84,31 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({error, errorDetails, onBut
 		},
 	];
 
+	if (errorMessage) {
+		return (
+			<View style={styles.container}>
+				<Typography type="heading" size="large" style={styles.errorMessageText}>
+					{errorMessage}
+				</Typography>
+			</View>
+		);
+	}
+
 	return (
 		<View style={styles.container}>
 			<Typography type="heading" size="large" style={styles.heading}>
 				Oops! Something went wrong.
 			</Typography>
 			{error && <Typography color={palette.error.main}>{error}</Typography>}
-			<Collapsible
-				wrapperStyle={styles.collapsibleWrapper}
-				header={() => ShowErrorDetailsButton()}
-				content={ErrorDetails}
-				data={data}
-				pressableComponent={TouchableOpacity}
-			/>
-			<View style={styles.goBackButtonWrapper}>
-				<Button value="Go Back" onPress={onButtonPress} />
-			</View>
+			{isDebug && (
+				<Collapsible
+					wrapperStyle={styles.collapsibleWrapper}
+					header={() => ShowErrorDetailsButton()}
+					content={ErrorDetails}
+					data={data}
+					pressableComponent={TouchableOpacity}
+				/>
+			)}
 		</View>
 	);
 };

--- a/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
+++ b/src/components/organisms/ErrorBoundary/components/ErrorFallback/index.tsx
@@ -56,28 +56,28 @@ const styles = StyleSheet.create({
 	},
 });
 
+const ShowErrorDetailsButton = () => {
+	return (
+		<View style={styles.showErrorButton}>
+			<Typography color={palette.base.white}>Show error details</Typography>
+		</View>
+	);
+};
+
+const ErrorDetails = ({errorDetails}: any) => {
+	return (
+		<View style={styles.errorDetails}>
+			<Typography color={palette.error.main}>{errorDetails}</Typography>
+		</View>
+	);
+};
+
 const ErrorFallback: React.FC<ErrorFallbackProps> = ({
 	error,
 	errorDetails,
 	isDebug,
 	errorMessage,
 }) => {
-	const ShowErrorDetailsButton = () => {
-		return (
-			<View style={styles.showErrorButton}>
-				<Typography color={palette.base.white}>Show error details</Typography>
-			</View>
-		);
-	};
-
-	const ErrorDetails = ({errorDetails}: any) => {
-		return (
-			<View style={styles.errorDetails}>
-				<Typography color={palette.error.main}>{errorDetails}</Typography>
-			</View>
-		);
-	};
-
 	const data = [
 		{
 			errorDetails,
@@ -103,7 +103,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
 			{isDebug && (
 				<Collapsible
 					wrapperStyle={styles.collapsibleWrapper}
-					header={() => ShowErrorDetailsButton()}
+					header={ShowErrorDetailsButton}
 					content={ErrorDetails}
 					data={data}
 					pressableComponent={TouchableOpacity}

--- a/src/components/organisms/ErrorBoundary/index.test.tsx
+++ b/src/components/organisms/ErrorBoundary/index.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {render, fireEvent} from '@testing-library/react-native';
+import ErrorBoundary from './index';
+import {Text, Button} from 'react-native';
+
+const ProblemChild = () => {
+	throw new Error('Oops!');
+};
+
+const ErrorFallbackMock = ({onButtonPress}: {onButtonPress: () => void}) => (
+	<>
+		<Text testID="error-fallback">Something went wrong</Text>
+		<Button title="Try Again" onPress={onButtonPress} />
+	</>
+);
+
+jest.mock('organisms/ErrorBoundary/components/ErrorFallback', () => ErrorFallbackMock);
+
+describe('ErrorBoundary', () => {
+	it('renders children when there is no error', () => {
+		const {getByTestId} = render(
+			<ErrorBoundary>
+				<Text testID="no-error">All good</Text>
+			</ErrorBoundary>
+		);
+
+		expect(getByTestId('no-error')).toBeTruthy();
+	});
+
+	it('renders fallback when an error is thrown', () => {
+		const {getByTestId} = render(
+			<ErrorBoundary>
+				<ProblemChild />
+			</ErrorBoundary>
+		);
+
+		expect(getByTestId('error-fallback')).toBeTruthy();
+	});
+
+	it('calls onError prop when an error is caught', () => {
+		const onError = jest.fn();
+
+		render(
+			<ErrorBoundary onError={onError}>
+				<ProblemChild />
+			</ErrorBoundary>
+		);
+
+		expect(onError).toHaveBeenCalled();
+	});
+
+	it('does not call onButtonPress prop when retry button is pressed as it was not passed', () => {
+		const onButtonPress = jest.fn();
+
+		const {getByText} = render(
+			<ErrorBoundary>
+				<ProblemChild />
+			</ErrorBoundary>
+		);
+
+		const retryButton = getByText('Try Again');
+		fireEvent.press(retryButton);
+
+		expect(onButtonPress).toBeCalledTimes(0);
+	});
+
+	it('calls onButtonPress prop when retry button is pressed', () => {
+		const onButtonPress = jest.fn();
+
+		const {getByText} = render(
+			<ErrorBoundary onButtonPress={onButtonPress}>
+				<ProblemChild />
+			</ErrorBoundary>
+		);
+
+		const retryButton = getByText('Try Again');
+		fireEvent.press(retryButton);
+
+		expect(onButtonPress).toHaveBeenCalled();
+	});
+});

--- a/src/components/organisms/ErrorBoundary/index.test.tsx
+++ b/src/components/organisms/ErrorBoundary/index.test.tsx
@@ -27,14 +27,17 @@ describe('ErrorBoundary', () => {
 		expect(getByTestId('no-error')).toBeTruthy();
 	});
 
-	it('renders fallback when an error is thrown', () => {
+	it('renders fallback when an error is thrown and calls onMount', () => {
+		const onMount = jest.fn();
+
 		const {getByTestId} = render(
-			<ErrorBoundary>
+			<ErrorBoundary onMount={onMount}>
 				<ProblemChild />
 			</ErrorBoundary>
 		);
 
 		expect(getByTestId('error-fallback')).toBeTruthy();
+		expect(onMount).toHaveBeenCalled();
 	});
 
 	it('calls onError prop when an error is caught', () => {

--- a/src/components/organisms/ErrorBoundary/index.test.tsx
+++ b/src/components/organisms/ErrorBoundary/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent} from '@testing-library/react-native';
+import {render} from '@testing-library/react-native';
 import ErrorBoundary from './index';
 import {Text, Button} from 'react-native';
 
@@ -49,33 +49,40 @@ describe('ErrorBoundary', () => {
 		expect(onError).toHaveBeenCalled();
 	});
 
-	it('does not call onButtonPress prop when retry button is pressed as it was not passed', () => {
-		const onButtonPress = jest.fn();
+	it('calls renderErrorComponent prop when it is passed', () => {
+		const renderErrorComponent = jest.fn(() => (
+			<Text testID="custom-fallback">Custom fallback</Text>
+		));
 
-		const {getByText} = render(
-			<ErrorBoundary>
+		render(
+			<ErrorBoundary renderErrorComponent={renderErrorComponent}>
 				<ProblemChild />
 			</ErrorBoundary>
 		);
 
-		const retryButton = getByText('Try Again');
-		fireEvent.press(retryButton);
-
-		expect(onButtonPress).toBeCalledTimes(0);
+		expect(renderErrorComponent).toHaveBeenCalled();
 	});
 
-	it('calls onButtonPress prop when retry button is pressed', () => {
-		const onButtonPress = jest.fn();
+	it('calls renderErrorComponent with empty string if error message is undefined', () => {
+		const renderErrorComponent = jest.fn(() => <Text testID="fallback" />);
 
-		const {getByText} = render(
-			<ErrorBoundary onButtonPress={onButtonPress}>
-				<ProblemChild />
+		class NoMessageError extends Error {
+			constructor() {
+				super();
+				(this.message as any) = undefined;
+			}
+		}
+
+		const SilentCrash = () => {
+			throw new NoMessageError();
+		};
+
+		render(
+			<ErrorBoundary renderErrorComponent={renderErrorComponent}>
+				<SilentCrash />
 			</ErrorBoundary>
 		);
 
-		const retryButton = getByText('Try Again');
-		fireEvent.press(retryButton);
-
-		expect(onButtonPress).toHaveBeenCalled();
+		expect(renderErrorComponent).toHaveBeenCalledWith('');
 	});
 });

--- a/src/components/organisms/ErrorBoundary/index.tsx
+++ b/src/components/organisms/ErrorBoundary/index.tsx
@@ -7,6 +7,7 @@ interface ErrorBoundaryProps {
 	errorMessage?: string;
 	renderErrorComponent?: (errorMessage: string) => ReactNode;
 	onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+	onMount?: () => void;
 }
 
 interface ErrorBoundaryState {
@@ -27,6 +28,12 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
 	static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
 		return {hasError: true, error};
+	}
+
+	componentDidMount(): void {
+		if (this.props.onMount) {
+			this.props.onMount();
+		}
 	}
 
 	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {

--- a/src/components/organisms/ErrorBoundary/index.tsx
+++ b/src/components/organisms/ErrorBoundary/index.tsx
@@ -3,8 +3,10 @@ import ErrorFallback from 'organisms/ErrorBoundary/components/ErrorFallback';
 
 interface ErrorBoundaryProps {
 	children: ReactNode;
+	isDebug?: boolean;
+	errorMessage?: string;
+	renderErrorComponent?: (errorMessage: string) => ReactNode;
 	onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
-	onButtonPress?: () => void;
 }
 
 interface ErrorBoundaryState {
@@ -35,19 +37,18 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 		}
 	}
 
-	handleRetry = () => {
-		this.setState({hasError: false, error: null, errorInfo: null}, () => {
-			if (this.props.onButtonPress) {
-				this.props.onButtonPress();
-			}
-		});
-	};
-
 	render() {
 		if (this.state.hasError) {
+			const {renderErrorComponent} = this.props;
+
+			if (typeof renderErrorComponent === 'function') {
+				return renderErrorComponent(this.state.error?.message || '');
+			}
+
 			return (
 				<ErrorFallback
-					onButtonPress={this.handleRetry}
+					isDebug={this.props.isDebug}
+					errorMessage={this.props.errorMessage}
 					error={this.state.error?.message}
 					errorDetails={this.state.errorInfo?.componentStack}
 				/>

--- a/src/components/organisms/ErrorBoundary/index.tsx
+++ b/src/components/organisms/ErrorBoundary/index.tsx
@@ -1,0 +1,61 @@
+import React, {ReactNode} from 'react';
+import ErrorFallback from 'organisms/ErrorBoundary/components/ErrorFallback';
+
+interface ErrorBoundaryProps {
+	children: ReactNode;
+	onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+	onButtonPress?: () => void;
+}
+
+interface ErrorBoundaryState {
+	hasError: boolean;
+	error: Error | null;
+	errorInfo: React.ErrorInfo | null;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+	constructor(props: ErrorBoundaryProps) {
+		super(props);
+		this.state = {
+			hasError: false,
+			error: null,
+			errorInfo: null,
+		};
+	}
+
+	static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+		return {hasError: true, error};
+	}
+
+	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+		this.setState({errorInfo});
+
+		if (this.props.onError) {
+			this.props.onError(error, errorInfo);
+		}
+	}
+
+	handleRetry = () => {
+		this.setState({hasError: false, error: null, errorInfo: null}, () => {
+			if (this.props.onButtonPress) {
+				this.props.onButtonPress();
+			}
+		});
+	};
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<ErrorFallback
+					onButtonPress={this.handleRetry}
+					error={this.state.error?.message}
+					errorDetails={this.state.errorInfo?.componentStack}
+				/>
+			);
+		}
+
+		return this.props.children;
+	}
+}
+
+export default ErrorBoundary;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import Input from 'molecules/Input';
 import LoadingFullScreen from 'organisms/LoadingFullScreen';
 import FullScreenMessage from 'organisms/FullScreenMessage';
 import SwipeItemSelectionList from 'organisms/SwipeItemSelectionList';
+import ErrorBoundary from 'organisms/ErrorBoundary';
 
 // Misc
 import {palette} from 'theme/palette';
@@ -73,4 +74,5 @@ export {
 	BaseInput,
 	Typography,
 	Collapsible,
+	ErrorBoundary,
 };

--- a/storybook/stories/ErrorBoundary/ErrorBoundary.stories.js
+++ b/storybook/stories/ErrorBoundary/ErrorBoundary.stories.js
@@ -1,12 +1,20 @@
 import React from 'react';
-import {StyleSheet, View, Text} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import Typography from 'atoms/Typography';
 import ErrorBoundary from 'components/organisms/ErrorBoundary';
+import {palette} from 'theme/palette';
 
 export default {
 	title: 'Components/ErrorBoundary',
 	argTypes: {
+		isDebug: {
+			control: {type: 'boolean'},
+		},
 		error: {
 			control: {type: 'boolean'},
+		},
+		errorMessage: {
+			control: {type: 'text'},
 		},
 	},
 };
@@ -17,14 +25,18 @@ const ThrowError = () => {
 
 const SafeComponent = () => (
 	<View style={styles.box}>
-		<Text style={styles.text}>No hay ningún error!</Text>
+		<Typography type="heading" size="large">
+			No hay ningún error!
+		</Typography>
 	</View>
 );
 
-export const Default = ({error}) => {
+export const Default = ({error, isDebug, errorMessage}) => {
 	return (
 		<View>
-			<ErrorBoundary>{error ? <ThrowError /> : <SafeComponent />}</ErrorBoundary>
+			<ErrorBoundary isDebug={isDebug} errorMessage={errorMessage}>
+				{error ? <ThrowError /> : <SafeComponent />}
+			</ErrorBoundary>
 		</View>
 	);
 };
@@ -33,6 +45,8 @@ Default.storyName = 'default';
 
 Default.args = {
 	error: false,
+	isDebug: true,
+	errorMessage: '',
 };
 
 const styles = StyleSheet.create({
@@ -42,8 +56,39 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 	},
-	text: {
-		fontSize: 16,
-		color: 'black',
-	},
 });
+
+const renderCustomComponent = (errorMessage) => (
+	<View style={styles.box}>
+		<Typography type="heading" size="large" color={palette.error.main}>
+			Ha ocurrido un error!
+		</Typography>
+		<Typography type="heading" size="large" color={palette.error.main}>
+			{errorMessage}
+		</Typography>
+		<Typography type="heading" size="medium" color={palette.black.main}>
+			Recuerde lo que hizo y trate de no hacerlo nuevamente
+		</Typography>
+	</View>
+);
+
+export const WithCustomComponent = ({error, isDebug, errorMessage}) => {
+	return (
+		<View>
+			<ErrorBoundary
+				isDebug={isDebug}
+				errorMessage={errorMessage}
+				renderErrorComponent={renderCustomComponent}>
+				{error ? <ThrowError /> : <SafeComponent />}
+			</ErrorBoundary>
+		</View>
+	);
+};
+
+WithCustomComponent.storyName = 'custom component';
+
+WithCustomComponent.args = {
+	error: false,
+	isDebug: true,
+	errorMessage: '',
+};

--- a/storybook/stories/ErrorBoundary/ErrorBoundary.stories.js
+++ b/storybook/stories/ErrorBoundary/ErrorBoundary.stories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import {StyleSheet, View, Text} from 'react-native';
+import ErrorBoundary from 'components/organisms/ErrorBoundary';
+
+export default {
+	title: 'Components/ErrorBoundary',
+	argTypes: {
+		error: {
+			control: {type: 'boolean'},
+		},
+	},
+};
+
+const ThrowError = () => {
+	throw new Error('Something went wrong!');
+};
+
+const SafeComponent = () => (
+	<View style={styles.box}>
+		<Text style={styles.text}>No hay ningún error!</Text>
+	</View>
+);
+
+export const Default = ({error}) => {
+	return (
+		<View>
+			<ErrorBoundary>{error ? <ThrowError /> : <SafeComponent />}</ErrorBoundary>
+		</View>
+	);
+};
+
+Default.storyName = 'default';
+
+Default.args = {
+	error: false,
+};
+
+const styles = StyleSheet.create({
+	box: {
+		padding: 20,
+		backgroundColor: 'white',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	text: {
+		fontSize: 16,
+		color: 'black',
+	},
+});


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/JUIP-170

DESCRIPCIÓN DEL REQUERIMIENTO: *

A partir de la implementación de la persistencia de la última pantalla en las distintas APPs se vió en más necesidad ([incluso aconsejada por la misma docu de react navigation](https://reactnavigation.org/docs/state-persistence/)) de contar con un ErrorBoundary para las tres apps por lo que se busca crear este componente

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se creó un componente ErrorBoundary, el cuál hace uso del componente ErrorFallback para mostrar el error que se produce junto a sus detalles en un colapsable (si la prop isDebug se encuentra en true), al ser pasado un errorMessage este se muestra por sobre el ErrorFallback y, si se la pasa un renderErrorComponent este será el que más prioridad tendrá para mostrarse. El componente ErrorBoundary se encarga de wrappear toda la App e identificar si se produce un error que crashee la app en cuestión

CÓMO SE PUEDE PROBAR? *

Wrappear el App.js con el componente ErrorBoundary dentro de la App de Picking o de Delivery (no en la App de WMS ya que la misma cuenta con un error en la inicialización de i18n el cuál genera una pantalla blanca cuándo crashea la App, esto ya se está solucionando en la implementación de la persistencia de última pantalla pero aún no llegó a producción) y generar un crasheo de la App, puede ser borrando una parte del código cómo de la siguiente manera:

`
const isFocused = seIsFocused();
`

Con sólo borrar una letra ya debería crashear, al estar probando localmente nos aparecerá la pantalla de error de React Native, pero al presionar el botón "Dismiss" deberíamos poder ver el componente ErrorBoundary

DEMO (VIEJA) *

https://gifyu.com/image/bM2cK

SCREENSHOTS *

Con isDebug en true y sin errorMessage ni renderErrorComponent
![Screenshot_1745265059](https://github.com/user-attachments/assets/29f8fb53-91d2-41b4-b22c-f41de6493eb8)

Sin isDebug en true y sin errorMessage ni renderErrorComponent
![Screenshot_1745265072](https://github.com/user-attachments/assets/ac8b58dc-40a8-4eaa-9e1c-e403691475ed)

Con errorMessage y sin renderErrorComponent
![Screenshot_1745265209](https://github.com/user-attachments/assets/c9376bd3-0d66-4050-a5c3-0229f6667132)

Con renderErrorComponent (haciendo uso del mensaje del error que se le pasa)
![Screenshot_1745266797](https://github.com/user-attachments/assets/f8a56d4f-cfb7-4dd6-8429-170c00b35f93)

