### PR TITLE
added Modal atom component

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -64,6 +64,7 @@ const getStories = () => {
 		'./storybook/stories/Loading/Loading.stories.js': require('../storybook/stories/Loading/Loading.stories.js'),
 		'./storybook/stories/LoadingFullScreen/LoadingFullScreen.stories.js': require('../storybook/stories/LoadingFullScreen/LoadingFullScreen.stories.js'),
 		'./storybook/stories/MainCardList/MainCardList.stories.js': require('../storybook/stories/MainCardList/MainCardList.stories.js'),
+		'./storybook/stories/Modal/Modal.stories.js': require('../storybook/stories/Modal/Modal.stories.js'),
 		'./storybook/stories/ProgressBar/ProgressBar.stories.js': require('../storybook/stories/ProgressBar/ProgressBar.stories.js'),
 		'./storybook/stories/RadioButton/RadioButton.stories.js': require('../storybook/stories/RadioButton/RadioButton.stories.js'),
 		'./storybook/stories/Select/Select.stories.js': require('../storybook/stories/Select/Select.stories.js'),

--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -49,13 +49,14 @@ describe('Modal component', () => {
 				close: () => void;
 			}>();
 
-			render(<Modal ref={ModalRef} />);
+			const {getByTestId} = render(<Modal ref={ModalRef} testID="modal-component" />);
 
 			act(() => {
 				ModalRef.current?.close();
 			});
 
 			expect(ModalRef.current).toBeDefined();
+			expect(getByTestId('modal-component').props.visible).toBe(false);
 		});
 	});
 });

--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -33,25 +33,22 @@ describe('Modal component', () => {
 
 			render(<Modal ref={ModalRef} />);
 
-			expect(ModalRef.current).toBeDefined();
 			act(() => {
 				ModalRef.current.openModal();
 			});
 
-			expect(ModalRef.current.isOpen).toBe(true);
+			expect(ModalRef.current).toBeDefined();
 		});
 		it('for close modal', () => {
 			const ModalRef = createRef<any>();
 
 			render(<Modal ref={ModalRef} />);
 
-			expect(ModalRef.current).toBeDefined();
 			act(() => {
-				ModalRef.current.openModal();
 				ModalRef.current.closeModal();
 			});
 
-			expect(ModalRef.current.isOpen).toBe(false);
+			expect(ModalRef.current).toBeDefined();
 		});
 	});
 });

--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -29,23 +29,30 @@ describe('Modal component', () => {
 
 	describe('should allow access to modal methods', () => {
 		it('for open modal', () => {
-			const ModalRef = createRef<any>();
+			const ModalRef = createRef<{
+				open: () => void;
+				close: () => void;
+			}>();
 
-			render(<Modal ref={ModalRef} />);
+			const {getByTestId} = render(<Modal ref={ModalRef} testID="modal-component" />);
 
 			act(() => {
-				ModalRef.current.openModal();
+				ModalRef.current?.open();
 			});
 
 			expect(ModalRef.current).toBeDefined();
+			expect(getByTestId('modal-component').props.visible).toBe(true);
 		});
 		it('for close modal', () => {
-			const ModalRef = createRef<any>();
+			const ModalRef = createRef<{
+				open: () => void;
+				close: () => void;
+			}>();
 
 			render(<Modal ref={ModalRef} />);
 
 			act(() => {
-				ModalRef.current.closeModal();
+				ModalRef.current?.close();
 			});
 
 			expect(ModalRef.current).toBeDefined();

--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -1,0 +1,57 @@
+import React, {createRef} from 'react';
+import {render} from '@testing-library/react-native';
+import {act, create} from 'react-test-renderer';
+import Modal from './index';
+import {View, Modal as NativeModal} from 'react-native';
+
+describe('Modal component', () => {
+	it('render defaulModal', () => {
+		const ModalComp = create(
+			<Modal>
+				<View />
+			</Modal>
+		);
+		const renderedModal = ModalComp.root.findByType(NativeModal);
+		renderedModal.props.onRequestClose();
+
+		expect(ModalComp.toJSON()).toBeTruthy();
+	});
+
+	it('render full screen modal', () => {
+		const mockFn = jest.fn();
+		const ModalComp = create(<Modal fullScreen showCloseButton customClose={mockFn} />);
+		const renderedModal = ModalComp.root.findByType(NativeModal);
+		renderedModal.props.onRequestClose();
+
+		expect(mockFn).toHaveBeenCalled();
+		expect(ModalComp.toJSON()).toBeTruthy();
+	});
+
+	describe('should allow access to modal methods', () => {
+		it('for open modal', () => {
+			const ModalRef = createRef<any>();
+
+			render(<Modal ref={ModalRef} />);
+
+			expect(ModalRef.current).toBeDefined();
+			act(() => {
+				ModalRef.current.openModal();
+			});
+
+			expect(ModalRef.current.isOpen).toBe(true);
+		});
+		it('for close modal', () => {
+			const ModalRef = createRef<any>();
+
+			render(<Modal ref={ModalRef} />);
+
+			expect(ModalRef.current).toBeDefined();
+			act(() => {
+				ModalRef.current.openModal();
+				ModalRef.current.closeModal();
+			});
+
+			expect(ModalRef.current.isOpen).toBe(false);
+		});
+	});
+});

--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -19,7 +19,7 @@ describe('Modal component', () => {
 
 	it('render full screen modal', () => {
 		const mockFn = jest.fn();
-		const ModalComp = create(<Modal fullScreen showCloseButton customClose={mockFn} />);
+		const ModalComp = create(<Modal fullScreen showCloseButton oncloseCallback={mockFn} />);
 		const renderedModal = ModalComp.root.findByType(NativeModal);
 		renderedModal.props.onRequestClose();
 

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -17,10 +17,10 @@ interface UIModalProps extends NativeModalProps {
 	showCloseButton?: boolean;
 	fullScreen?: boolean;
 	modalContainerStyle?: ViewStyle;
+	canClose?: boolean;
 }
 
 interface RefProps {
-	isOpen?: boolean;
 	showModal?: () => void;
 	closeModal?: () => void;
 }
@@ -31,6 +31,7 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 			children = null,
 			customClose = undefined,
 			showCloseButton = false,
+			canClose = true,
 			animationType = 'fade',
 			transparent = true,
 			fullScreen = false,
@@ -51,9 +52,6 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 		};
 
 		useImperativeHandle(ref, () => ({
-			get isOpen() {
-				return isVisible;
-			},
 			openModal: () => setIsVisible(true),
 			closeModal: () => setIsVisible(false),
 		}));
@@ -104,11 +102,15 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 			<NativeModal
 				visible={isVisible}
 				transparent={transparent}
-				onRequestClose={handleClose}
 				animationType={animationType}
-				{...props}>
+				{...props}
+				{...(canClose && {
+					onRequestClose: handleClose,
+				})}>
 				<View style={styles.Overlay}>
-					{!fullScreen && <Pressable style={StyleSheet.absoluteFill} onPress={handleClose} />}
+					{!fullScreen && (
+						<Pressable style={StyleSheet.absoluteFill} disabled={!canClose} onPress={handleClose} />
+					)}
 					<View
 						style={
 							fullScreen

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -21,9 +21,58 @@ export interface UIModalProps extends NativeModalProps {
 }
 
 interface RefProps {
-	showModal?: () => void;
-	closeModal?: () => void;
+	open?: () => void;
+	close?: () => void;
 }
+
+const styles = StyleSheet.create({
+	Overlay: {
+		flex: 1,
+		backgroundColor: 'rgba(0,0,0,0.6)',
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	ModalWrapper: {
+		backgroundColor: palette.base.white,
+		alignItems: 'center',
+		justifyContent: 'center',
+		elevation: 12,
+		minWidth: horizontalScale(50),
+		width: horizontalScale(280),
+		marginHorizontal: horizontalScale(20),
+		borderRadius: verticalScale(18),
+		zIndex: 1,
+	},
+	Shadow: {
+		shadowOffset: {
+			width: 0,
+			height: 2,
+		},
+		shadowOpacity: 0.25,
+	},
+	FullScreen: {
+		position: 'absolute',
+		top: 0,
+		bottom: 0,
+		left: 0,
+		right: 0,
+		backgroundColor: palette.base.white,
+		zIndex: 2,
+	},
+	HeaderWrapper: {
+		flexDirection: 'row',
+		justifyContent: 'flex-end',
+		alignItems: 'center',
+		zIndex: 3,
+		minHeight: verticalScale(52),
+		backgroundColor: palette.base.white,
+	},
+	CloseButton: {
+		position: 'absolute',
+		top: moderateScale(12),
+		right: moderateScale(12),
+	},
+});
 
 const Modal = forwardRef<RefProps, UIModalProps>(
 	(
@@ -51,58 +100,9 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 		};
 
 		useImperativeHandle(ref, () => ({
-			openModal: () => setIsVisible(true),
-			closeModal: () => setIsVisible(false),
+			open: () => setIsVisible(true),
+			close: () => setIsVisible(false),
 		}));
-
-		const styles = StyleSheet.create({
-			Overlay: {
-				flex: 1,
-				backgroundColor: fullScreen ? 'transparent' : 'rgba(0,0,0,0.6)',
-				justifyContent: 'center',
-				alignItems: 'center',
-			},
-			ModalWrapper: {
-				backgroundColor: palette.base.white,
-				alignItems: 'center',
-				justifyContent: 'center',
-				elevation: 12,
-				minWidth: horizontalScale(50),
-				width: horizontalScale(280),
-				marginHorizontal: horizontalScale(20),
-				borderRadius: verticalScale(18),
-				zIndex: 1,
-			},
-			Shadow: {
-				shadowOffset: {
-					width: 0,
-					height: 2,
-				},
-				shadowOpacity: 0.25,
-			},
-			FullScreen: {
-				position: 'absolute',
-				top: 0,
-				bottom: 0,
-				left: 0,
-				right: 0,
-				backgroundColor: palette.base.white,
-				zIndex: 2,
-			},
-			HeaderWrapper: {
-				flexDirection: 'row',
-				justifyContent: 'flex-end',
-				alignItems: 'center',
-				zIndex: 3,
-				minHeight: verticalScale(52),
-				backgroundColor: palette.base.white,
-			},
-			CloseButton: {
-				position: 'absolute',
-				top: moderateScale(12),
-				right: moderateScale(12),
-			},
-		});
 
 		return (
 			<NativeModal
@@ -124,7 +124,11 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 								: [styles.ModalWrapper, styles.Shadow, modalContainerStyle]
 						}>
 						{renderCloseButton && canClose && (
-							<Pressable onPress={handleClose} style={styles.HeaderWrapper}>
+							<Pressable
+								onPress={handleClose}
+								style={styles.HeaderWrapper}
+								accessibilityLabel="Close modal"
+								accessibilityRole="button">
 								<Icon
 									name="cross_light"
 									size={24}

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -1,0 +1,131 @@
+import Icon from 'atoms/Icon';
+import React, {useState, forwardRef, useImperativeHandle} from 'react';
+import {
+	Modal as NativeModal,
+	ModalProps as NativeModalProps,
+	Pressable,
+	StyleSheet,
+	View,
+	ViewStyle,
+} from 'react-native';
+import {horizontalScale} from 'scale';
+import {verticalScale} from 'scale';
+import {palette} from 'theme/palette';
+
+interface UIModalProps extends NativeModalProps {
+	customClose?: () => void;
+	showCloseButton?: boolean;
+	fullScreen?: boolean;
+	modalContainerStyle?: ViewStyle;
+}
+
+interface RefProps {
+	isOpen?: boolean;
+	showModal?: () => void;
+	closeModal?: () => void;
+}
+
+const Modal = forwardRef<RefProps, UIModalProps>(
+	(
+		{
+			children = null,
+			customClose = undefined,
+			showCloseButton = false,
+			animationType = 'fade',
+			transparent = true,
+			fullScreen = false,
+			modalContainerStyle = {},
+			...props
+		}: UIModalProps,
+		ref
+	) => {
+		const [isVisible, setIsVisible] = useState(false);
+		const renderCloseButton = fullScreen && showCloseButton;
+
+		const handleClose = () => {
+			if (!customClose) {
+				return setIsVisible(false);
+			}
+
+			customClose();
+		};
+
+		useImperativeHandle(ref, () => ({
+			get isOpen() {
+				return isVisible;
+			},
+			openModal: () => setIsVisible(true),
+			closeModal: () => setIsVisible(false),
+		}));
+
+		const styles = StyleSheet.create({
+			Overlay: {
+				flex: 1,
+				backgroundColor: fullScreen ? 'transparent' : 'rgba(0,0,0,0.6)',
+				justifyContent: 'center',
+				alignItems: 'center',
+			},
+			ModalWrapper: {
+				backgroundColor: palette.base.white,
+				alignItems: 'center',
+				justifyContent: 'center',
+				elevation: 12,
+				minWidth: horizontalScale(50),
+				width: horizontalScale(280),
+				marginHorizontal: horizontalScale(20),
+				borderRadius: verticalScale(18),
+				zIndex: 1,
+			},
+			Shadow: {
+				shadowOffset: {
+					width: 0,
+					height: 2,
+				},
+				shadowOpacity: 0.25,
+			},
+			FullScreen: {
+				position: 'absolute',
+				top: 0,
+				bottom: 0,
+				left: 0,
+				right: 0,
+				backgroundColor: palette.base.white,
+				zIndex: 2,
+			},
+			CloseButton: {
+				position: 'absolute',
+				top: verticalScale(5),
+				right: horizontalScale(5),
+				zIndex: 3,
+			},
+		});
+
+		return (
+			<NativeModal
+				visible={isVisible}
+				transparent={transparent}
+				onRequestClose={handleClose}
+				animationType={animationType}
+				{...props}>
+				<View style={styles.Overlay}>
+					{!fullScreen && <Pressable style={StyleSheet.absoluteFill} onPress={handleClose} />}
+					<View
+						style={
+							fullScreen
+								? styles.FullScreen
+								: [styles.ModalWrapper, styles.Shadow, modalContainerStyle]
+						}>
+						{renderCloseButton && (
+							<Pressable onPress={handleClose} style={styles.CloseButton}>
+								<Icon name="cross_light" size={24} color={palette.black.main} />
+							</Pressable>
+						)}
+						{children}
+					</View>
+				</View>
+			</NativeModal>
+		);
+	}
+);
+
+export default Modal;

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -116,7 +116,7 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 								? styles.FullScreen
 								: [styles.ModalWrapper, styles.Shadow, modalContainerStyle]
 						}>
-						{renderCloseButton && (
+						{renderCloseButton && canClose && (
 							<Pressable onPress={handleClose} style={styles.CloseButton}>
 								<Icon name="cross_light" size={24} color={palette.black.main} />
 							</Pressable>

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -12,8 +12,8 @@ import {horizontalScale} from 'scale';
 import {verticalScale} from 'scale';
 import {palette} from 'theme/palette';
 
-interface UIModalProps extends NativeModalProps {
-	customClose?: () => void;
+export interface UIModalProps extends NativeModalProps {
+	oncloseCallback?: () => void;
 	showCloseButton?: boolean;
 	fullScreen?: boolean;
 	modalContainerStyle?: ViewStyle;
@@ -29,7 +29,7 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 	(
 		{
 			children = null,
-			customClose = undefined,
+			oncloseCallback = undefined,
 			showCloseButton = false,
 			canClose = true,
 			animationType = 'fade',
@@ -44,11 +44,10 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 		const renderCloseButton = fullScreen && showCloseButton;
 
 		const handleClose = () => {
-			if (!customClose) {
-				return setIsVisible(false);
+			if (oncloseCallback) {
+				oncloseCallback();
 			}
-
-			customClose();
+			setIsVisible(false);
 		};
 
 		useImperativeHandle(ref, () => ({

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -9,7 +9,7 @@ import {
 	ViewStyle,
 } from 'react-native';
 import {horizontalScale} from 'scale';
-import {verticalScale} from 'scale';
+import {verticalScale, moderateScale} from 'scale';
 import {palette} from 'theme/palette';
 
 export interface UIModalProps extends NativeModalProps {
@@ -89,11 +89,18 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 				backgroundColor: palette.base.white,
 				zIndex: 2,
 			},
+			HeaderWrapper: {
+				flexDirection: 'row',
+				justifyContent: 'flex-end',
+				alignItems: 'center',
+				zIndex: 3,
+				minHeight: verticalScale(52),
+				backgroundColor: palette.base.white,
+			},
 			CloseButton: {
 				position: 'absolute',
-				top: verticalScale(5),
-				right: horizontalScale(5),
-				zIndex: 3,
+				top: moderateScale(12),
+				right: moderateScale(12),
 			},
 		});
 
@@ -117,8 +124,13 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 								: [styles.ModalWrapper, styles.Shadow, modalContainerStyle]
 						}>
 						{renderCloseButton && canClose && (
-							<Pressable onPress={handleClose} style={styles.CloseButton}>
-								<Icon name="cross_light" size={24} color={palette.black.main} />
+							<Pressable onPress={handleClose} style={styles.HeaderWrapper}>
+								<Icon
+									name="cross_light"
+									size={24}
+									color={palette.black.main}
+									style={styles.CloseButton}
+								/>
 							</Pressable>
 						)}
 						{children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import Text from 'atoms/Text';
 import BaseInput from 'atoms/BaseInput';
 import Typography from 'atoms/Typography';
 import Collapsible from 'atoms/Collapsible';
+import Modal from 'atoms/Modal';
 
 // Molecules
 import Avatar from 'molecules/Avatar';
@@ -73,4 +74,5 @@ export {
 	BaseInput,
 	Typography,
 	Collapsible,
+	Modal,
 };

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -1,0 +1,125 @@
+import React, {useRef} from 'react';
+import Modal from 'atoms/Modal';
+import {View, Text, Pressable, StyleSheet} from 'react-native';
+
+const text =
+	"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
+
+const styles = StyleSheet.create({
+	centeredView: {
+		flex: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	modalView: {
+		marginVertical: 15,
+	},
+	button: {
+		borderRadius: 20,
+		padding: 10,
+		elevation: 2,
+	},
+	buttonOpen: {
+		backgroundColor: '#2196F3',
+	},
+	buttonClose: {
+		backgroundColor: '#2196F3',
+	},
+	textStyle: {
+		color: 'white',
+		fontWeight: 'bold',
+		textAlign: 'center',
+	},
+	modalText: {
+		marginBottom: 15,
+		textAlign: 'center',
+	},
+	fullScreenView: {
+		marginTop: 45,
+		marginHorizontal: 10,
+	},
+});
+
+const OpenModal = ({...props}) => {
+	return (
+		<Pressable style={[styles.button, styles.buttonOpen]} {...props}>
+			<Text style={styles.textStyle}>Show Modal</Text>
+		</Pressable>
+	);
+};
+
+export const DefaultModal = ({...props}) => {
+	const ModalRef = useRef(null);
+
+	const handleOpenModal = () => {
+		ModalRef.current.openModal();
+	};
+
+	const handleCloseModal = () => {
+		ModalRef.current.closeModal();
+	};
+
+	return (
+		<View style={styles.centeredView}>
+			<OpenModal onPress={handleOpenModal} />
+			<Modal ref={ModalRef} {...props}>
+				<View style={styles.modalView}>
+					<Text style={styles.modalText}>Hello World!</Text>
+					<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
+						<Text style={styles.textStyle}>Hide Modal</Text>
+					</Pressable>
+				</View>
+			</Modal>
+		</View>
+	);
+};
+
+export const FullScreenModal = ({...props}) => {
+	const ModalRef = useRef(null);
+
+	const handleOpenModal = () => {
+		ModalRef.current.openModal();
+	};
+
+	const handleCloseModal = () => {
+		ModalRef.current.closeModal();
+	};
+
+	return (
+		<View style={styles.centeredView}>
+			<OpenModal onPress={handleOpenModal} />
+			<Modal ref={ModalRef} {...props} fullScreen>
+				<View style={styles.fullScreenView}>
+					<View>
+						<Text style={styles.modalText}>{text + text + text}</Text>
+						<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
+							<Text style={styles.textStyle}>Hide Modal</Text>
+						</Pressable>
+					</View>
+				</View>
+			</Modal>
+		</View>
+	);
+};
+
+DefaultModal.args = {
+	animationType: 'fade',
+	transparent: true,
+};
+
+FullScreenModal.args = {
+	animationType: 'fade',
+	showCloseButton: true,
+};
+
+export default {
+	title: 'Components/Modal',
+	argTypes: {
+		animationType: {
+			control: {
+				type: 'select',
+			},
+			options: ['fade', 'slide', 'none'],
+		},
+	},
+};

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -105,11 +105,13 @@ export const FullScreenModal = ({...props}) => {
 DefaultModal.args = {
 	animationType: 'fade',
 	transparent: true,
+	canClose: true,
 };
 
 FullScreenModal.args = {
 	animationType: 'fade',
 	showCloseButton: true,
+	canClose: true,
 };
 
 export default {

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -88,10 +88,10 @@ export const FullScreenModal = ({...props}) => {
 	return (
 		<View style={styles.centeredView}>
 			<OpenModal onPress={handleOpenModal} />
-			<Modal ref={ModalRef} {...props} fullScreen>
+			<Modal ref={ModalRef} {...props}>
 				<View style={styles.fullScreenView}>
 					<View>
-						<Text style={styles.modalText}>{text + text + text}</Text>
+						<Text style={styles.modalText}>{text + text}</Text>
 						<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
 							<Text style={styles.textStyle}>Hide Modal</Text>
 						</Pressable>
@@ -112,6 +112,7 @@ FullScreenModal.args = {
 	animationType: 'fade',
 	showCloseButton: true,
 	canClose: true,
+	fullScreen: true,
 };
 
 export default {

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -52,11 +52,11 @@ export const DefaultModal = ({...props}) => {
 	const ModalRef = useRef(null);
 
 	const handleOpenModal = () => {
-		ModalRef.current.openModal();
+		ModalRef.current.open();
 	};
 
 	const handleCloseModal = () => {
-		ModalRef.current.closeModal();
+		ModalRef.current.close();
 	};
 
 	return (
@@ -78,11 +78,11 @@ export const FullScreenModal = ({...props}) => {
 	const ModalRef = useRef(null);
 
 	const handleOpenModal = () => {
-		ModalRef.current.openModal();
+		ModalRef.current.open();
 	};
 
 	const handleCloseModal = () => {
-		ModalRef.current.closeModal();
+		ModalRef.current.close();
 	};
 
 	return (

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react';
 import Modal from 'atoms/Modal';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {View, Text, Pressable, StyleSheet, ScrollView} from 'react-native';
 
 const text =
 	"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
@@ -35,8 +35,8 @@ const styles = StyleSheet.create({
 		textAlign: 'center',
 	},
 	fullScreenView: {
-		marginTop: 45,
 		marginHorizontal: 10,
+		paddingBottom: 10,
 	},
 });
 
@@ -89,14 +89,12 @@ export const FullScreenModal = ({...props}) => {
 		<View style={styles.centeredView}>
 			<OpenModal onPress={handleOpenModal} />
 			<Modal ref={ModalRef} {...props}>
-				<View style={styles.fullScreenView}>
-					<View>
-						<Text style={styles.modalText}>{text + text}</Text>
-						<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
-							<Text style={styles.textStyle}>Hide Modal</Text>
-						</Pressable>
-					</View>
-				</View>
+				<ScrollView contentContainerStyle={styles.fullScreenView}>
+					<Text style={styles.modalText}>{text + text}</Text>
+					<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
+						<Text style={styles.textStyle}>Hide Modal</Text>
+					</Pressable>
+				</ScrollView>
 			</Modal>
 		</View>
 	);


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-368

DESCRIPCIÓN DEL REQUERIMIENTO: *

Contar con un modal reutilizable que nos permita simplificar la implementación tanto en las apps como en los componentes de la librería de ui-native

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se armó el componente `Modal` como parte de los atomos de la librería.
Este componente extiende las propiedades del Modal de [react native](https://reactnative.dev/docs/modal), permite wrappear un children y renderizarlo en pantalla, y agrega propiedades nuevas que condicionan el tipo de modal que se va a utilizar.

Las propiedades son:
- `fullScreen`
- `showCloseButton`
- `customClose`
- `modalContainerStyle`

`fullScreen` permite renderizar el modal en pantalla completa cuando es true. En caso contrario, el modal sólo ocupa parte de la pantalla y por detrás se renderiza una máscara transparente que, al presionarla, cierra el modal.
`showCloseButton` funciona para mostrar una cruz en la esquina derecha superior que permite cerrar el modal. Esta cruz sólo se mostrará cuando está prop, en conjunto con `fullScreen`, estén en `true`.
`customClose` sobreescribe el comportamiento de cierre del modal, por lo que, al utilizarlo, se debe agregar el métdo closeModal para cerrarlo.
`modalContainerStyle` permite cambiar los estilos del contenedor del modal para cuando esté no se muestra en su tamaño `fullScreen`

Para manejar el estado del modal se agregó `forwardRef` para poder recibir una referencia externa y poder acceder a los métodos:
- `openModal`
- `closeModal`
- `isOpen`: indica si el modal está abierto o no.

¿CÓMO PROBARLO?

Revisar el funcionamiento en storybook web o mobile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable Modal component with support for full-screen mode, close buttons, and imperative open/close methods.
  - Added the Modal component to the main export, making it available for use throughout the app.
- **Tests**
  - Added comprehensive tests to verify Modal rendering, close behavior, and ref-based control.
- **Storybook**
  - Added Storybook stories to showcase default and full-screen Modal variants for interactive preview and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->