### PR TITLE
Appsrn 371 desarrollo de base detail y product detail

### DIFF
--- a/src/components/atoms/Modal/index.test.tsx
+++ b/src/components/atoms/Modal/index.test.tsx
@@ -19,7 +19,17 @@ describe('Modal component', () => {
 
 	it('render full screen modal', () => {
 		const mockFn = jest.fn();
-		const ModalComp = create(<Modal fullScreen showCloseButton customClose={mockFn} />);
+		const ModalComp = create(<Modal fullScreen showCloseButton customCloseBehavior={mockFn} />);
+		const renderedModal = ModalComp.root.findByType(NativeModal);
+		renderedModal.props.onRequestClose();
+
+		expect(mockFn).toHaveBeenCalled();
+		expect(ModalComp.toJSON()).toBeTruthy();
+	});
+
+	it('should execute onclosecallback function when modal is closed', () => {
+		const mockFn = jest.fn();
+		const ModalComp = create(<Modal fullScreen showCloseButton onCloseCallback={mockFn} />);
 		const renderedModal = ModalComp.root.findByType(NativeModal);
 		renderedModal.props.onRequestClose();
 

--- a/src/components/atoms/Modal/index.tsx
+++ b/src/components/atoms/Modal/index.tsx
@@ -13,7 +13,8 @@ import {verticalScale} from 'scale';
 import {palette} from 'theme/palette';
 
 interface UIModalProps extends NativeModalProps {
-	customClose?: () => void;
+	customCloseBehavior?: () => void;
+	onCloseCallback?: () => void;
 	showCloseButton?: boolean;
 	fullScreen?: boolean;
 	modalContainerStyle?: ViewStyle;
@@ -29,7 +30,8 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 	(
 		{
 			children = null,
-			customClose = undefined,
+			onCloseCallback = undefined,
+			customCloseBehavior = undefined,
 			showCloseButton = false,
 			canClose = true,
 			animationType = 'fade',
@@ -44,11 +46,14 @@ const Modal = forwardRef<RefProps, UIModalProps>(
 		const renderCloseButton = fullScreen && showCloseButton;
 
 		const handleClose = () => {
-			if (!customClose) {
-				return setIsVisible(false);
+			if (customCloseBehavior) {
+				return customCloseBehavior();
+			}
+			if (onCloseCallback) {
+				onCloseCallback();
 			}
 
-			customClose();
+			setIsVisible(false);
 		};
 
 		useImperativeHandle(ref, () => ({

--- a/src/components/molecules/BaseDetail/components/BaseDetailModal/index.tsx
+++ b/src/components/molecules/BaseDetail/components/BaseDetailModal/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {forwardRef} from 'react';
+import React, {forwardRef} from 'react';
 import {BaseModalProps} from '../../types';
 import Modal, {ModalMethods} from 'atoms/Modal';
 import {ScrollView} from 'react-native';

--- a/src/components/molecules/BaseDetail/components/BaseDetailModal/index.tsx
+++ b/src/components/molecules/BaseDetail/components/BaseDetailModal/index.tsx
@@ -1,0 +1,17 @@
+import { Ref } from "react"
+import { BaseModalProps } from "../../types"
+import Modal from "atoms/Modal";
+import { ScrollView } from "react-native";
+const BaseDetailModal = (props: BaseModalProps, ref : Ref<any>) => {
+    const {children, scrollProps = {}, ...modalProps} = props;
+
+    return (
+        <Modal ref={ref} {...modalProps}>
+            <ScrollView showsVerticalScrollIndicator={false} {...scrollProps}>
+                {children}
+            </ScrollView>
+        </Modal>
+    );
+}
+
+export default BaseDetailModal;

--- a/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.test.tsx
+++ b/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.test.tsx
@@ -6,9 +6,7 @@ import {SwipeUpScrollView} from 'atoms/SwipeUp/childComponents';
 describe('BaseDetailSwipe', () => {
 	it('should return Scrolleable Swipe with nested children', () => {
 		const BaseDetailSwipeComp = create(
-			<BaseDetailSwipe componentType="swipe">
-				<></>
-			</BaseDetailSwipe>
+			<BaseDetailSwipe componentType="swipe">{null}</BaseDetailSwipe>
 		).root;
 
 		const ScrolleableComp = BaseDetailSwipeComp.findByType(SwipeUpScrollView);

--- a/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.tsx
+++ b/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, {forwardRef} from 'react';
 import SwipeUp from 'atoms/SwipeUp';
 import {BaseSwipeUpProps} from 'molecules/BaseDetail/types';
-import {forwardRef} from 'react';
 import {SwipeUpScrollView} from 'atoms/SwipeUp/childComponents';
 import BottomSheet from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheet/BottomSheet';
 

--- a/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.tsx
+++ b/src/components/molecules/BaseDetail/components/BaseDetailSwipe/index.tsx
@@ -1,0 +1,18 @@
+import SwipeUp from "atoms/SwipeUp";
+import { BaseSwipeUpProps } from "molecules/BaseDetail/types"
+import { Ref } from "react"
+import { SwipeUpScrollView } from "atoms/SwipeUp/childComponents";
+
+const BaseDetailSwipe = (props: BaseSwipeUpProps, ref: Ref<any>) => {
+    const {children, scrollProps = {}, ...swipeProps} = props;
+
+    return (
+        <SwipeUp ref={ref} {...swipeProps}>
+            <SwipeUpScrollView showsVerticalScrollIndicator={false} {...scrollProps}>
+                {children}
+            </SwipeUpScrollView>
+        </SwipeUp>
+    )
+}
+
+export default BaseDetailSwipe

--- a/src/components/molecules/BaseDetail/components/index.tsx
+++ b/src/components/molecules/BaseDetail/components/index.tsx
@@ -1,0 +1,7 @@
+import BaseDetailModal from "./BaseDetailModal";
+import BaseDetailSwipe from "./BaseDetailSwipe";
+
+export {
+    BaseDetailModal,
+    BaseDetailSwipe
+}

--- a/src/components/molecules/BaseDetail/index.test.tsx
+++ b/src/components/molecules/BaseDetail/index.test.tsx
@@ -1,30 +1,31 @@
-import React from 'react';
+import React, {createRef} from 'react';
 import {create} from 'react-test-renderer';
-import BaseDetail from './index';
+import BaseDetail, {BaseDetailMethods} from './index';
 import {BaseDetailModal, BaseDetailSwipe} from './components';
 
 describe('BaseDetail', () => {
 	it('should return BaseDetailSwipe when componentType is "swipe"', () => {
-		const BaseDetailComp = create(
-			<BaseDetail componentType="swipe">
-				<></>
-			</BaseDetail>
-		).root;
+		const BaseDetailComp = create(<BaseDetail componentType="swipe">{null}</BaseDetail>).root;
 
 		const BaseDetailSwipeComp = BaseDetailComp.findByType(BaseDetailSwipe);
 
 		expect(BaseDetailSwipeComp).toBeTruthy();
 	});
 
-	it('should return BaseDetailModal when componentType is "swipe"', () => {
+	it('should return BaseDetailModal when componentType is "modal"', () => {
+		const ModalRef = createRef<BaseDetailMethods>();
+
 		const BaseDetailComp = create(
-			<BaseDetail componentType="modal">
-				<></>
+			<BaseDetail componentType="modal" ref={ModalRef}>
+				{null}
 			</BaseDetail>
 		).root;
 
 		const BaseDetailModalComp = BaseDetailComp.findByType(BaseDetailModal);
 
+		expect(ModalRef.current).toBeTruthy();
+		expect(typeof ModalRef.current?.open).toBe('function');
+		expect(typeof ModalRef.current?.close).toBe('function');
 		expect(BaseDetailModalComp).toBeTruthy();
 	});
 });

--- a/src/components/molecules/BaseDetail/index.tsx
+++ b/src/components/molecules/BaseDetail/index.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
-import {forwardRef} from 'react';
+import React, {forwardRef} from 'react';
 import {BaseModalProps, BaseSwipeUpProps} from './types';
 import {BaseDetailModal, BaseDetailSwipe} from './components';
 import {ModalMethods} from 'atoms/Modal';
 import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 
 type BaseDetailProps = BaseModalProps | BaseSwipeUpProps;
-type BaseDetailMethods = ModalMethods & BottomSheetMethods;
+export type BaseDetailMethods = ModalMethods & BottomSheetMethods;
 
 const BaseDetail = forwardRef<BaseDetailMethods, BaseDetailProps>((props, ref) => {
 	if (props.componentType === 'swipe') {

--- a/src/components/molecules/BaseDetail/index.tsx
+++ b/src/components/molecules/BaseDetail/index.tsx
@@ -1,0 +1,14 @@
+import { forwardRef } from "react";
+import { BaseModalProps, BaseSwipeUpProps } from "./types";
+import { BaseDetailModal, BaseDetailSwipe } from "./components";
+
+export type BaseDetailProps = BaseModalProps | BaseSwipeUpProps
+
+const BaseDetail = forwardRef<any, BaseDetailProps>((props, ref) => {
+    if (props.componentType === 'swipe') return BaseDetailSwipe(props, ref);
+      
+    return BaseDetailModal({ ...props, ...{fullScreen:true}, componentType: 'modal' }, ref);
+})
+
+
+export default BaseDetail;

--- a/src/components/molecules/BaseDetail/types/index.ts
+++ b/src/components/molecules/BaseDetail/types/index.ts
@@ -1,0 +1,8 @@
+import { BottomSheetScrollViewProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetScrollable/types";
+import { UIModalProps } from "atoms/Modal";
+import { SwipeUpProps } from "atoms/SwipeUp";
+import { ScrollViewProps } from "react-native";
+
+export type ComponentType = 'modal' | 'swipe';
+export type BaseModalProps = {componentType: 'modal'} & UIModalProps & {scrollProps?: ScrollViewProps};
+export type BaseSwipeUpProps = {componentType: 'swipe'} & SwipeUpProps & {scrollProps? : BottomSheetScrollViewProps};

--- a/src/components/organisms/ProductDetail/components/ProductInfo/index.test.tsx
+++ b/src/components/organisms/ProductDetail/components/ProductInfo/index.test.tsx
@@ -13,6 +13,9 @@ describe('ProductInfo', () => {
 		const ImageComp = ProductInfoComp.findByType(Image);
 
 		expect(ImageComp).toBeTruthy();
+		expect(ImageComp.props.source).toEqual({
+			uri: 'https://avatars.githubusercontent.com/u/49998302?s=200&v=4',
+		});
 		expect(ProductInfoComp).toBeTruthy();
 	});
 

--- a/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
+++ b/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
 	},
 	productInfo: {
 		height: 'auto',
+		width: moderateScale(312),
 		marginTop: verticalScale(24),
 	},
 	productName: {

--- a/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
+++ b/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import Image from "atoms/Image";
+import Typography from "atoms/Typography";
+import { View, StyleSheet } from 'react-native';
+import { horizontalScale, moderateScale } from 'scale';
+import { verticalScale } from 'scale';
+import { palette } from 'theme/palette';
+import FastImage from 'react-native-fast-image';
+
+export interface ProductProps {
+    brand?: string,
+    productName?: string,
+    refId?: string,
+    image?: string,
+}
+
+const ProductInfo = ({brand, productName, refId, image}: ProductProps) => {
+
+    const styles = StyleSheet.create({
+        Wrapper: {
+            flex:1,
+            alignItems: 'center',
+            paddingVertical: verticalScale(12),
+            marginHorizontal: horizontalScale(24),
+        },
+        productImage: {
+            height: moderateScale(312),
+            width: moderateScale(312),
+            marginTop: verticalScale(16)
+        },
+        productInfo: {
+            height: 'auto',
+            marginTop: verticalScale(24),
+        },
+        productName: {
+            marginTop: verticalScale(16),
+        },
+        referenceId: {
+            marginTop: verticalScale(16),
+        }
+    })
+
+    if(image && !image.length) {
+        FastImage.preload([{
+            uri: String(image)
+        }]);
+    }
+
+    return (
+            <View style={styles.Wrapper}>
+            {!!image && <Image source={{uri:String(image)}} style={styles.productImage}/>}
+            <View style={styles.productInfo}>
+                {!!brand && <Typography color={palette.primary.main} type="overline" size="large">{String(brand)}</Typography>}
+                {!!productName && <Typography color={palette.black.main} type='heading' size='medium' style={styles.productName}>{String(productName)}</Typography>}
+                {!!refId && <Typography color={palette.black.main} type='heading' size='small' style={styles.referenceId}>{String(refId)}</Typography>}   
+            </View>
+            </View>
+    )
+}
+
+export default ProductInfo;

--- a/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
+++ b/src/components/organisms/ProductDetail/components/ProductInfo/index.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import Image from 'atoms/Image';
 import Typography from 'atoms/Typography';
 import {View, StyleSheet} from 'react-native';
-import {horizontalScale, moderateScale} from 'scale';
-import {verticalScale} from 'scale';
+import {horizontalScale, moderateScale, verticalScale} from 'scale';
 import {palette} from 'theme/palette';
 
 export interface ProductProps {

--- a/src/components/organisms/ProductDetail/index.tsx
+++ b/src/components/organisms/ProductDetail/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, {forwardRef} from 'react';
 import {BaseModalProps, BaseSwipeUpProps} from 'molecules/BaseDetail/types';
 import BaseDetail from 'molecules/BaseDetail';
 import ProductInfo, {ProductProps} from './components/ProductInfo';
-import {forwardRef} from 'react';
 import {ModalMethods} from 'atoms/Modal';
 import {BottomSheetMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
 

--- a/src/components/organisms/ProductDetail/index.tsx
+++ b/src/components/organisms/ProductDetail/index.tsx
@@ -1,0 +1,20 @@
+import { BaseModalProps, BaseSwipeUpProps } from "molecules/BaseDetail/types";
+import BaseDetail from "molecules/BaseDetail";
+import ProductInfo,{ProductProps} from "./components/ProductInfo";
+import { forwardRef } from "react";
+
+type ProductDetailProps =   
+    | (ProductProps & BaseModalProps)
+    | (ProductProps & BaseSwipeUpProps);
+
+const ProductDetail = forwardRef((props: ProductDetailProps, ref) => {
+    const { brand, productName, refId, image, ...rest } = props; 
+
+    return (
+        <BaseDetail ref={ref} {...rest}>
+            <ProductInfo image={image} refId={refId} productName={productName} brand={brand}/>
+        </BaseDetail>
+    )}
+);
+      
+export default ProductDetail;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,13 @@ import SwipeList from 'molecules/SwipeList';
 import ItemSelectionButton from 'molecules/ItemSelectionButton';
 import MainCardList from 'molecules/MainCardList';
 import Input from 'molecules/Input';
+import BaseDetail from 'molecules/BaseDetail';
 
 // Organisms
 import LoadingFullScreen from 'organisms/LoadingFullScreen';
 import FullScreenMessage from 'organisms/FullScreenMessage';
 import SwipeItemSelectionList from 'organisms/SwipeItemSelectionList';
+import ProductDetail from 'organisms/ProductDetail';
 
 // Misc
 import {palette} from 'theme/palette';
@@ -75,4 +77,6 @@ export {
 	Typography,
 	Collapsible,
 	Modal,
+	BaseDetail,
+	ProductDetail
 };

--- a/storybook/stories/Modal/Modal.stories.js
+++ b/storybook/stories/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react';
 import Modal from 'atoms/Modal';
-import {View, Text, Pressable, StyleSheet} from 'react-native';
+import {View, Text, Pressable, StyleSheet, Alert} from 'react-native';
 
 const text =
 	"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
@@ -91,8 +91,43 @@ export const FullScreenModal = ({...props}) => {
 			<Modal ref={ModalRef} {...props} fullScreen>
 				<View style={styles.fullScreenView}>
 					<View>
-						<Text style={styles.modalText}>{text + text + text}</Text>
+						<Text style={styles.modalText}>{text}</Text>
 						<Pressable style={[styles.button, styles.buttonClose]} onPress={handleCloseModal}>
+							<Text style={styles.textStyle}>Hide Modal</Text>
+						</Pressable>
+					</View>
+				</View>
+			</Modal>
+		</View>
+	);
+};
+
+export const CustomCloseModal = ({...props}) => {
+	const ModalRef = useRef(null);
+
+	const handleOpenModal = () => {
+		ModalRef.current.openModal();
+	};
+
+	const handleCloseModal = () => {
+		ModalRef.current.closeModal();
+	};
+
+	const openAlert = () => {
+		return Alert.alert('¿cerrar modal?', 'Confirme el cierre del modal', [
+			{text: 'cancel', onPress: () => null},
+			{text: 'confirm', onPress: handleCloseModal},
+		]);
+	};
+
+	return (
+		<View style={styles.centeredView}>
+			<OpenModal onPress={handleOpenModal} />
+			<Modal ref={ModalRef} customCloseBehavior={openAlert} {...props}>
+				<View style={styles.fullScreenView}>
+					<View>
+						<Text style={styles.modalText}>{text + text + text}</Text>
+						<Pressable style={[styles.button, styles.buttonClose]} onPress={openAlert}>
 							<Text style={styles.textStyle}>Hide Modal</Text>
 						</Pressable>
 					</View>
@@ -111,6 +146,13 @@ DefaultModal.args = {
 FullScreenModal.args = {
 	animationType: 'fade',
 	showCloseButton: true,
+	canClose: true,
+};
+
+CustomCloseModal.args = {
+	animationType: 'fade',
+	showCloseButton: true,
+	fullScreen: false,
 	canClose: true,
 };
 


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-366

DESCRIPCIÓN DEL REQUERIMIENTO: *

Actualmente la APP de Orders (Modulo de Picking) tiene una limitación para mostrar los nombres de los productos en el detalle del mismo, y esa es que aquellos nombres que superan los 52 caracteres son finalizados con “…” por lo que no se muestra en su totalidad.

En algunos casos esto puede representar un problema ya que hay productos que, si bien son similares, la diferencia entre ellos viene detallada en el nombre (medidas o colores). Estos detalles agregan una mayor extensión al nombre del producto, lo que provoca que, en la mayoría de casos, la app no termine de comunicar el nombre correcto al picker.
Necesidad

Para estos casos necesitamos tener la posibilidad de mirar el nombre completo, y para ello se propone contar con un modal que permita visualizar tanto la imagen del producto a mayor escala, como su nombre completo sin puntos suspensivos, tal cuál presenta el diseño 


DESCRIPCIÓN DE LA SOLUCIÓN: *

Se agregaron 2 nuevos componentes:
 El primero es el componente `BaseDetail`, que es una molecula  "base" que sirve para envolver y representar un children dentro de un componente Modal o un componente SwipeUp. Para definir qué componente utilizar en cada caso el `BaseDetail` espera recibir una prop `componentType` que condicionará el tipo de componente representado como wrapper, y que sólo puede ser de tipo 'swipe' o 'modal'. 

El segundo es el componente `ProductDetail` que utiliza internamente el `BaseDetail` para representar, en un modal o un swipe, información asociada a un producto.
La información que espera recibir este componente es:
- la imagen del producto
- su refId
- su marca
- su nombre

Ambos componentes están preparados para recibir una propiedad `ref` que permita acceder a los métodos correspondientes de los componentes swipeUp y modal desde fuera de los mismos.

DATOS EXTRA A TENER EN CUENTA:
Se agregaron componentes secundarios que son utilizados por ambos componentes principales para evitar tener componentes muy extensos y agrupar varias definiciones de tipos, estilos e interfaces en el mismo archivo.
Estos componentes son BaseDetailModal, BaseDetailSwipe y ProductInfo:
 - El primero renderiza el componente `Modal` anidando un componente `scrollView`, lo que permitirá scrollear el children recibido como argumento en `BaseDetail`. Este componente será utilizado por `BaseDetail` cuando el valor recibido para `componentType` sea `modal`

 - El segundo es similar al primero, pero en vez de un `scrollView` renderiza el componente `SwipeUp` anidando el componente `SwipeUpScrollView`. Este cambio de componentes scrolleables se debe a que, para poder scrollear dentro del swipe, es necesario contar con un componente que sea adecuado y que permita responder al gesto del scroll. Este componente se renderizará cuando el valor de `componentType` para `BaseDetail` sea `swipe`

- El tercero es utilizado por `ProductDetail` para representar los valores recibidos como argumentos para las propiedades `image`, `productName`, `brand` y `refId`
 
CÓMO SE PUEDE PROBAR? *

Para probarlo alcanza con levantar storybook android y/o web,

SCREENSHOTS:
![productDetailPicking](https://github.com/user-attachments/assets/ab28e8f0-631b-46e4-8c69-a7181ba95c8a)
![productDetailPickingSwipe](https://github.com/user-attachments/assets/d99e7587-9a8c-4f3a-bc64-bb38a4baf5f2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `ProductDetail`, a flexible component for displaying product information in modal or swipe-up styles.
  - Added `BaseDetail`, `BaseDetailModal`, and `BaseDetailSwipe` components for customizable detail presentation.
  - Included `ProductInfo` component for structured display of product brand, name, reference ID, and image.
  - Exported `BaseDetail` and `ProductDetail` for external use.
  - Added Storybook stories for both modal and swipe-up variants of `ProductDetail`.

- **Tests**
  - Added comprehensive tests for `BaseDetail`, `BaseDetailModal`, `BaseDetailSwipe`, `ProductDetail`, and `ProductInfo` components.

- **Refactor**
  - Renamed and exported modal method interface for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->