### PR TITLE
Fixed List component not passing the props properly

### DIFF
--- a/src/components/atoms/List/index.test.tsx
+++ b/src/components/atoms/List/index.test.tsx
@@ -8,6 +8,8 @@ const data = [
 	{id: 2, nombre: 'nombre2'},
 ];
 
+const dataWithoutId = [{nombre: 'nombre1'}, {nombre: 'nombre2'}];
+
 const renderComponent = ({item}: any) => (
 	<View key={item.id}>
 		<Text>{item.nombre}</Text>
@@ -24,7 +26,7 @@ describe('List component', () => {
 
 	describe('render correctlt when', () => {
 		it('data is array type and type is flatList per default', () => {
-			const {toJSON} = create(<List data={data} renderComponent={renderComponent} />);
+			const {toJSON} = create(<List data={dataWithoutId} renderComponent={renderComponent} />);
 			expect(toJSON()).toBeTruthy();
 		});
 

--- a/src/components/atoms/List/index.tsx
+++ b/src/components/atoms/List/index.tsx
@@ -1,35 +1,59 @@
 import React, {FC} from 'react';
 import {FlatList, ScrollView, FlatListProps, ScrollViewProps} from 'react-native';
 
-type TypeData = string | number | object | [] | React.ReactElement;
+type TypeData = any;
 type RCProps = {
 	item: TypeData;
 	index: number;
 };
 type TypeRenderComponent = ({item, index}: RCProps) => React.ReactElement;
+
 export enum TypeList {
 	FlatList = 'flatList',
 	ScrollView = 'scrollView',
 }
 
-interface ListProps {
+interface BaseProps {
 	data: TypeData[] | undefined;
 	renderComponent: TypeRenderComponent;
 	type?: TypeList;
 }
-type MergedProps = ListProps & (FlatListProps<TypeData> | ScrollViewProps);
 
-const List: FC<MergedProps> = ({data, renderComponent, type = TypeList.FlatList, ...props}) => {
+type FlatListOnlyProps = Omit<FlatListProps<TypeData>, 'data' | 'renderItem'> & {
+	type?: TypeList.FlatList;
+};
+
+type ScrollViewOnlyProps = ScrollViewProps & {
+	type: TypeList.ScrollView;
+};
+
+type ListProps = BaseProps & (FlatListOnlyProps | ScrollViewOnlyProps);
+
+const List: FC<ListProps> = ({data, renderComponent, type = TypeList.FlatList, ...props}) => {
 	if (!data?.length) {
 		return null;
 	}
 
-	const FlatListComponent = () => <FlatList data={data} renderItem={renderComponent} {...props} />;
-	const ScrollViewComponent = () => (
-		<ScrollView {...props}>{data.map((item, index) => renderComponent({item, index}))}</ScrollView>
-	);
+	if (type === TypeList.ScrollView) {
+		const scrollProps = props as ScrollViewOnlyProps;
 
-	return type === TypeList.FlatList ? <FlatListComponent /> : <ScrollViewComponent />;
+		return (
+			<ScrollView {...scrollProps}>
+				{data.map((item, index) => renderComponent({item, index}))}
+			</ScrollView>
+		);
+	}
+
+	const cleanedFlatProps = props as FlatListOnlyProps;
+
+	return (
+		<FlatList
+			data={data}
+			renderItem={({item, index}) => renderComponent({item, index})}
+			keyExtractor={(item, index) => String((item as any).id ?? index)}
+			{...cleanedFlatProps}
+		/>
+	);
 };
 
 export default List;


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/JUIP-171
LINK DE SUBTAREA:
https://janiscommerce.atlassian.net/browse/JUIP-172

DESCRIPCIÓN DEL REQUERIMIENTO: *
Tras realizar un ajuste en base al siguiente HDI: https://janiscommerce.atlassian.net/browse/HDI-2760?searchObjectId=167248&searchContainerId=12368&searchContentType=issue&searchSessionId=a61f2f67-0860-48b3-b852-bc5b0e43b3ba se encontró que al componente List de UI-Native no se le está pudiendo pasar la prop extraData la cuál es necesaria para decirle al componente que se renderice sólo si se actualiza x data pasada, por lo que se busca hacerlo posible.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se modificó el componente List para que, a partir del tipo que haya sido elegido, se extiendan las props de FlatList o de ScrollView, de esta manera TypeScript ya sabe las props que tiene que pasar correctamente y no sólo se va a estar pasando correctamente la prop extraData de FlatList, si no también otras props tanto de ScrollView cómo de FlatList van a estar funcionando correctamente

CÓMO PROBARLO?:

Esto se puede probar en Delivery que es dónde se encontró el error: https://bitbucket.org/fizzmodsrl/janis-delivery-app/pull-requests/1183. Para esto debemos dirigirnos a src/screens/DespatchV2/DespatchList/styles.js, dentro de este archivo deberemos modificar lo siguiente:

`const RouteList = styled.FlatList``;`

Esa línea de código deberá utilizar el componente List de UI-Native en vez del FlatList. Y, a partir de los ajustes hechos en este PR lo que no debería suceder es el error de que el scroll volviera al principio automaticamente, cosa que sucedía en el HDI de Delivery al presionar una Card de Ruta de Despacho V2 debido a que el listado se re-renderizaba al no tener en cuenta la prop extraData del componente List.

![653860633-lastSelect](https://github.com/user-attachments/assets/2af8e8bc-f690-49a0-a839-f5d3fe5a5eaa)


SCREENSHOTS:

Datos extra a tener en cuenta: